### PR TITLE
(Almost) Complete topology API

### DIFF
--- a/src/gromacs/nblib/topology.h
+++ b/src/gromacs/nblib/topology.h
@@ -18,21 +18,30 @@ namespace nblib {
 class Topology {
 public:
 
-    const std::vector<int>& getAtoms() const;
+    const std::vector<int>& atoms() const;
 
-    const std::vector<real>& getCharges() const;
+    const std::vector<real>& charges() const;
 
-    const std::vector<real>& getMasses() const;
+    const std::vector<real>& masses() const;
 
-    const std::vector<real>& getNonbondedParameters() const;
+    const std::vector<real>& nonbondedParameters() const;
 
-    const std::vector<int>& getAtomInfoAllVdw() const;
+    const std::vector<int>& atomTypes() const;
+
+    const std::vector<int>& atomInfoAllVdw() const;
+
+    int numAtoms() const
+    {
+        // TODO
+        // Revisit this return value
+        return charges_.size();
+    }
 
     // TODO: This function is only needed for testing. Need
     //       another way for testing exclusion correctness
     const t_blocka& getGMXexclusions() const
     {
-        return excls;
+        return excls_;
     }
 
 private:
@@ -41,17 +50,19 @@ private:
     friend class TopologyBuilder;
 
     //! Storage for parameters for short range interactions.
-    std::vector<real>      nonbondedParameters;
+    std::vector<real>      nonbondedParameters_;
     //! Storage for atom type parameters.
-    std::vector<int>       atomTypes;
+    std::vector<int>       atomTypes_;
     //! Storage for atom partial charges.
-    std::vector<real>      charges;
+    std::vector<real>      charges_;
     //! Atom masses
-    std::vector<real>      masses;
+    std::vector<real>      masses_;
     //! Atom info where all atoms are marked to have Van der Waals interactions
-    std::vector<int>       atomInfoAllVdw;
+    std::vector<int>       atomInfoAllVdw_;
     //! Information about exclusions.
-    t_blocka               excls;
+    t_blocka               excls_;
+
+
 };
 
 class TopologyBuilder {
@@ -66,12 +77,15 @@ private:
     Topology topology_;
 
     int numAtoms_;
+
     std::vector<std::tuple<Molecule, int>> molecules_;
 
     t_blocka createExclusionsList() const;
 
     template <class Extractor>
     std::vector<real> extractQuantity(Extractor extractor);
+
+    void extractAllProperties();
 };
 
 } // namespace nblib


### PR DESCRIPTION
# Improves 
* The consistency between the other APIs
* Change the entire interface from `getXxxx()` to `xXxxx()`.
* Replaces the `std::vector<real> TopologyBuilder::extractQuantity(Extractor extractor)` method by 
`void TopologyBuilder::extractAllProperties()`, which also populates the `topology_.nonbondedParameters_` and `topology_.atomInfoAllVdw_` members.

# Bad points:
* There is still a missing point a proper definition of `numAtoms()` definition