### PR TITLE
Provide a Box to GMX matrix converter

### DIFF
--- a/src/gromacs/nblib/box.cpp
+++ b/src/gromacs/nblib/box.cpp
@@ -39,4 +39,17 @@ Box::data_type Box::matrix()
     return box_;
 }
 
+void convertBoxToGMXFormat(Box &box, matrix matrix)
+{
+    matrix[XX][XX] = box.matrix()[XX][XX];
+    matrix[XX][YY] = box.matrix()[XX][YY];
+    matrix[XX][ZZ] = box.matrix()[XX][ZZ];
+    matrix[YY][XX] = box.matrix()[YY][XX];
+    matrix[YY][YY] = box.matrix()[YY][YY];
+    matrix[YY][ZZ] = box.matrix()[YY][ZZ];
+    matrix[ZZ][XX] = box.matrix()[ZZ][XX];
+    matrix[ZZ][YY] = box.matrix()[ZZ][YY];
+    matrix[ZZ][ZZ] = box.matrix()[ZZ][ZZ];
+}
+
 } // namespace nblib

--- a/src/gromacs/nblib/box.h
+++ b/src/gromacs/nblib/box.h
@@ -8,6 +8,8 @@
 #include <array>
 #include "gromacs/math/vectypes.h"
 
+#include "gromacs/math/vec.h"
+
 namespace nblib
 {
 
@@ -24,6 +26,9 @@ public:
 private:
     data_type box_;
 };
+
+void convertBoxToGMXFormat(Box &box, matrix matrix);
+
 
 } // namespace nblib
 


### PR DESCRIPTION
# Background

GROMACS interface relies on the `matrix` datatype to operate on matrixes.
Example code is
```
GMX_RELEASE_ASSERT(!TRICLINIC(boxMatrix), "Only rectangular unit-cells are supported here");
...
const real atomDensity = simulationState.coordinates().size()/det(boxMatrix);
```
For more examples please refer to #4 .
