### PR TITLE
Remove unused variables from simulation state

### DIFF
--- a/src/gromacs/nblib/simulationstate.cpp
+++ b/src/gromacs/nblib/simulationstate.cpp
@@ -57,21 +57,7 @@
 #include "gromacs/pbcutil/pbc.h"
 #include "gromacs/utility/fatalerror.h"
 
-
-
 #include "coords.h"
-
-namespace
-{
-
-//! The number of atoms in a molecule
-constexpr int  numAtomsInMolecule = 1;
-//! The atom type of the atom
-constexpr int  atomType         = 0;
-//! The charge of the atom
-constexpr real atomCharge       = 0.0;
-
-}   // namespace
 
 namespace nblib {
 

--- a/src/gromacs/nblib/simulationstate.h
+++ b/src/gromacs/nblib/simulationstate.h
@@ -62,6 +62,7 @@ namespace nblib
 class SimulationState
 {
 public:
+
     // Constructor
     SimulationState(const std::vector<gmx::RVec> &coord, Box box, Topology &topo,
              const std::vector<gmx::RVec> &vel = {});


### PR DESCRIPTION
Remove unused variables that just produce compilation warnings.

They are not needed on the intermediate `mdrunner` and `forcecalculator` APIs. Please take a look at #4 .