### PR TITLE
Move charge from AtomType to Molecule and make molecule.addAtoms() ty…

### DIFF
--- a/src/gromacs/nblib/atomtype.cpp
+++ b/src/gromacs/nblib/atomtype.cpp
@@ -9,15 +9,13 @@ namespace nblib {
 AtomType::AtomType() noexcept :
   name_(""),
   mass_(0),
-  charge_(0),
   c6_(0),
   c12_(0)
 {}
 
-AtomType::AtomType(std::string atomName, real mass, real charge, real c6, real c12)
+AtomType::AtomType(std::string atomName, real mass, real c6, real c12)
 : name_(std::move(atomName)),
   mass_(mass),
-  charge_(charge),
   c6_(c6),
   c12_(c12)
 {}
@@ -25,8 +23,6 @@ AtomType::AtomType(std::string atomName, real mass, real charge, real c6, real c
 std::string AtomType::name() const { return name_; }
 
 real AtomType::mass() const { return mass_; }
-
-real AtomType::charge() const { return charge_; }
 
 real AtomType::c6() const { return c6_; }
 

--- a/src/gromacs/nblib/atomtype.h
+++ b/src/gromacs/nblib/atomtype.h
@@ -24,15 +24,12 @@ public:
 
     AtomType(std::string atomName,
              real mass,
-             real charge,
              real c6,
              real c12);
 
     std::string name() const;
 
     real mass() const;
-
-    real charge() const;
 
     real c6() const;
 
@@ -41,7 +38,6 @@ public:
 private:
     std::string name_;
     real mass_;
-    real charge_;
     real c6_;
     real c12_;
 };

--- a/src/gromacs/nblib/molecules.cpp
+++ b/src/gromacs/nblib/molecules.cpp
@@ -31,12 +31,12 @@ void Molecule::addAtomSelfExclusion(std::string atomName, std::string resName)
     }
 }
 
-Molecule& Molecule::addAtom(const std::string &atomName, const std::string &residueName, AtomType const &atomType)
+Molecule& Molecule::addAtom(const AtomName& atomName, const ResidueName& residueName, const Charge& charge, AtomType const &atomType)
 {
-    // check whether we already have the atom type
-    if (!atomTypes_.count(atomType.name()))
+    // this check can only ensure that we don't use the same atomName twice, not that an (AtomType, charge) pair is not repeated
+    if (!atomTypes_.count(atomName))
     {
-        atomTypes_[atomName] = atomType;
+        atomTypes_[atomName] = std::make_tuple(atomType, charge);
     }
 
     atoms_.emplace_back(std::make_tuple(atomName, residueName));
@@ -45,9 +45,25 @@ Molecule& Molecule::addAtom(const std::string &atomName, const std::string &resi
     return *this;
 }
 
-Molecule& Molecule::addAtom(const std::string &atomName, AtomType const &atomType)
+Molecule& Molecule::addAtom(const AtomName& atomName, const ResidueName& residueName, AtomType const &atomType)
 {
-    addAtom(atomName, name_, atomType);
+    real charge = 0;
+    addAtom(atomName, residueName, charge, atomType);
+
+    return *this;
+}
+
+Molecule& Molecule::addAtom(const AtomName& atomName, const Charge& charge, AtomType const &atomType)
+{
+    addAtom(atomName, name_, charge, atomType);
+
+    return *this;
+}
+
+Molecule& Molecule::addAtom(const AtomName& atomName, const AtomType& atomType)
+{
+    real charge = 0;
+    addAtom(atomName, name_, charge, atomType);
 
     return *this;
 }

--- a/src/gromacs/nblib/molecules.h
+++ b/src/gromacs/nblib/molecules.h
@@ -20,13 +20,21 @@ class TopologyBuilder;
 namespace nblib
 {
 
+using AtomName = std::string;
+using Charge = real;
+using ResidueName = std::string;
+
 class Molecule {
 public:
     Molecule(std::string moleculeName);
 
-    Molecule& addAtom(const std::string &atomName, const std::string &residueName, AtomType const &atomType);
+    Molecule& addAtom(const AtomName& atomName, const ResidueName& residueName, const Charge& charge, AtomType const &atomType);
 
-    Molecule& addAtom(const std::string &atomName, AtomType const &atomType);
+    Molecule& addAtom(const AtomName& atomName, const ResidueName& residueName, AtomType const &atomType);
+
+    Molecule& addAtom(const AtomName& atomName, const Charge& charge, AtomType const &atomType);
+
+    Molecule& addAtom(const AtomName& atomName, AtomType const &atomType);
 
     void addHarmonicBond(HarmonicType harmonicBond);
 
@@ -46,8 +54,9 @@ private:
 
     //! one entry per atom in molecule
     std::vector<std::tuple<std::string, std::string>> atoms_;
+
     //! collection of distinct Atoms in molecule
-    std::unordered_map<std::string, AtomType> atomTypes_;
+    std::unordered_map<std::string, std::tuple<AtomType, real>> atomTypes_;
 
     std::vector<std::tuple<int, int>> exclusions_;
 

--- a/src/gromacs/nblib/tests/atoms.cpp
+++ b/src/gromacs/nblib/tests/atoms.cpp
@@ -56,7 +56,6 @@ struct ArAtom
 {
     std::string name = "Ar";
     real mass = 1.0;
-    real charge = 0;
     real c6 = 1;
     real c12 = 1;
 };
@@ -64,35 +63,28 @@ struct ArAtom
 TEST(NBlibTest, AtomNameCanBeConstructed)
 {
     ArAtom arAtom;
-    AtomType argonAtom(arAtom.name, arAtom.mass, arAtom.charge, arAtom.c6, arAtom.c12);
+    AtomType argonAtom(arAtom.name, arAtom.mass, arAtom.c6, arAtom.c12);
     EXPECT_EQ(argonAtom.name(), arAtom.name);
 }
 
 TEST(NBlibTest, AtomMassCanBeConstructed)
 {
     ArAtom arAtom;
-    AtomType argonAtom(arAtom.name, arAtom.mass, arAtom.charge, arAtom.c6, arAtom.c12);
+    AtomType argonAtom(arAtom.name, arAtom.mass, arAtom.c6, arAtom.c12);
     EXPECT_EQ(argonAtom.mass(), arAtom.mass);
-}
-
-TEST(NBlibTest, AtomChargeCanBeConstructed)
-{
-    ArAtom arAtom;
-    AtomType argonAtom(arAtom.name, arAtom.mass, arAtom.charge, arAtom.c6, arAtom.c12);
-    EXPECT_EQ(argonAtom.charge(), arAtom.charge);
 }
 
 TEST(NBlibTest, AtomC6CanBeConstructed)
 {
     ArAtom arAtom;
-    AtomType argonAtom(arAtom.name, arAtom.mass, arAtom.charge, arAtom.c6, arAtom.c12);
+    AtomType argonAtom(arAtom.name, arAtom.mass, arAtom.c6, arAtom.c12);
     EXPECT_EQ(argonAtom.c6(), arAtom.c6);
 }
 
 TEST(NBlibTest, AtomC12CanBeConstructed)
 {
     ArAtom arAtom;
-    AtomType argonAtom(arAtom.name, arAtom.mass, arAtom.charge, arAtom.c6, arAtom.c12);
+    AtomType argonAtom(arAtom.name, arAtom.mass, arAtom.c6, arAtom.c12);
     EXPECT_EQ(argonAtom.c12(), arAtom.c12);
 }
 

--- a/src/gromacs/nblib/tests/molecules.cpp
+++ b/src/gromacs/nblib/tests/molecules.cpp
@@ -51,38 +51,51 @@ namespace nblib {
 namespace test {
 namespace {
 
-Molecule generateWaterMolecule()
+TEST(NBlibTest, CanConstructMoleculeWithoutChargeOrResidueName)
+{
+    AtomType Ar("Ar", 40, 1., 1.);
+    Molecule argon("Ar");
+    EXPECT_NO_THROW(argon.addAtom(AtomName("Ar"), Ar));
+}
+
+TEST(NBlibTest, CanConstructMoleculeWithChargeWithoutResidueName)
+{
+    AtomType Ar("Ar", 40, 1., 1.);
+    Molecule argon("Ar");
+    EXPECT_NO_THROW(argon.addAtom(AtomName("Ar"), Charge(0), Ar));
+}
+
+TEST(NBlibTest, CanConstructMoleculeWithoutChargeWithResidueName)
+{
+    AtomType Ar("Ar", 40, 1., 1.);
+    Molecule argon("Ar");
+    EXPECT_NO_THROW(argon.addAtom(AtomName("Ar"), ResidueName("ar2"), Ar));
+}
+
+TEST(NBlibTest, CanConstructMoleculeWithChargeWithResidueName)
+{
+    AtomType Ar("Ar", 40, 1., 1.);
+    Molecule argon("Ar");
+    EXPECT_NO_THROW(argon.addAtom(AtomName("Ar"),  ResidueName("ar2"), Charge(0), Ar));
+}
+
+TEST(NBlibTest, CanGetNumAtomsInMolecule)
 {
     //! Manually Create Molecule (Water)
 
     //! 1. Define Atom Type
-    AtomType Ow("Ow", 16, -0.6, 1., 1.);
-    AtomType Hw("Hw", 1, +0.3, 1., 1.);
-    AtomType Ar("Ar", 40, 0., 1., 1.);
+    AtomType Ow("Ow", 16, 1., 1.);
+    AtomType Hw("Hw", 1, 1., 1.);
 
     //! 2. Define Molecule
-
-    //! 2.1 Water
     Molecule water("water");
 
-    water.addAtom("Oxygen", Ow);
-    water.addAtom("H1", Hw);
+    water.addAtom("Oxygen", Charge(-0.6), Ow);
+    water.addAtom("H1", Charge(+0.3), Hw);
     water.addAtom("H2", Hw);
 
-    water.addHarmonicBond(HarmonicType{1, 2, "H1", "Oxygen"});
-    water.addHarmonicBond(HarmonicType{1, 2, "H2", "Oxygen"});
-
-    water.addExclusion("Oxygen", "H1");
-    water.addExclusion("Oxygen", "H2");
-    water.addExclusion("H1", "H2");
-
-    return water;
-}
-
-TEST(NBlibTest, numAtomsTest)
-{
-    auto water = generateWaterMolecule();
     auto numAtoms = water.numAtomsInMolecule();
+
     EXPECT_EQ(3, numAtoms);
 }
 

--- a/src/gromacs/nblib/tests/simstate.cpp
+++ b/src/gromacs/nblib/tests/simstate.cpp
@@ -77,7 +77,7 @@ public:
     {
         constexpr int NumArgonAtoms = 3;
 
-        AtomType argonAtom("AR", 39.94800, 0.0, 0.0062647225, 9.847044e-06);
+        AtomType argonAtom("AR", 39.94800, 0.0062647225, 9.847044e-06);
 
         Molecule argonMolecule("AR");
         argonMolecule.addAtom("AR", argonAtom);

--- a/src/gromacs/nblib/topology.cpp
+++ b/src/gromacs/nblib/topology.cpp
@@ -78,7 +78,7 @@ t_blocka TopologyBuilder::createExclusionsList() const
 }
 
 template <class Extractor>
-std::vector<real> TopologyBuilder::extractQuantity(Extractor extractor)
+std::vector<real> TopologyBuilder::extractAtomTypeQuantity(Extractor extractor)
 {
     auto &moleculesList = molecules_;
 
@@ -97,8 +97,36 @@ std::vector<real> TopologyBuilder::extractQuantity(Extractor extractor)
             {
                 std::string atomTypeName = std::get<1>(atomTuple);
 
-                AtomType &atomType = molecule.atomTypes_[atomTypeName];
+                AtomType &atomType = std::get<0>(molecule.atomTypes_[atomTypeName]);
                 ret.push_back(extractor(atomType));
+            }
+        }
+    }
+
+    return ret;
+}
+
+std::vector<real> TopologyBuilder::extractCharge()
+{
+    auto &moleculesList = molecules_;
+
+    //! returned object
+    std::vector<real> ret;
+    ret.reserve(numAtoms_);
+
+    for (auto &molNumberTuple : moleculesList)
+    {
+        Molecule &molecule = std::get<0>(molNumberTuple);
+        size_t numMols = std::get<1>(molNumberTuple);
+
+        for (size_t i = 0; i < numMols; ++i)
+        {
+            for (auto &atomTuple : molecule.atoms_)
+            {
+                std::string atomTypeName = std::get<1>(atomTuple);
+
+                real charge = std::get<1>(molecule.atomTypes_[atomTypeName]);
+                ret.push_back(charge);
             }
         }
     }
@@ -109,8 +137,8 @@ std::vector<real> TopologyBuilder::extractQuantity(Extractor extractor)
 Topology TopologyBuilder::buildTopology()
 {
     topology_.excls = createExclusionsList();
-    topology_.masses = extractQuantity([](const AtomType &atomType){ return atomType.mass(); });
-    topology_.charges = extractQuantity([](const AtomType &atomType){ return atomType.charge(); });
+    topology_.masses = extractAtomTypeQuantity([](const AtomType &atomType){ return atomType.mass(); });
+    topology_.charges = extractCharge();
 
     return topology_;
 }

--- a/src/gromacs/nblib/topology.cpp
+++ b/src/gromacs/nblib/topology.cpp
@@ -165,36 +165,8 @@ std::vector<real> TopologyBuilder::extractAtomTypeQuantity(Extractor extractor)
             {
                 std::string atomTypeName = std::get<1>(atomTuple);
 
-                AtomType &atomType = std::get<0>(molecule.atomTypes_[atomTypeName]);
-                ret.push_back(extractor(atomType));
-            }
-        }
-    }
-
-    return ret;
-}
-
-std::vector<real> TopologyBuilder::extractCharge()
-{
-    auto &moleculesList = molecules_;
-
-    //! returned object
-    std::vector<real> ret;
-    ret.reserve(numAtoms_);
-
-    for (auto &molNumberTuple : moleculesList)
-    {
-        Molecule &molecule = std::get<0>(molNumberTuple);
-        size_t numMols = std::get<1>(molNumberTuple);
-
-        for (size_t i = 0; i < numMols; ++i)
-        {
-            for (auto &atomTuple : molecule.atoms_)
-            {
-                std::string atomTypeName = std::get<1>(atomTuple);
-
-                real charge = std::get<1>(molecule.atomTypes_[atomTypeName]);
-                ret.push_back(charge);
+                const auto &atcTup = molecule.atomTypes_[atomTypeName];
+                ret.push_back(extractor(atcTup));
             }
         }
     }
@@ -205,8 +177,8 @@ std::vector<real> TopologyBuilder::extractCharge()
 Topology TopologyBuilder::buildTopology()
 {
     topology_.excls = createExclusionsList();
-    topology_.masses = extractAtomTypeQuantity([](const AtomType &atomType){ return atomType.mass(); });
-    topology_.charges = extractCharge();
+    topology_.masses = extractAtomTypeQuantity([](const auto &atcTup){ return std::get<0>(atcTup).mass(); });
+    topology_.charges = extractAtomTypeQuantity([](const auto &atcTup){ return std::get<1>(atcTup); });
 
     return topology_;
 }

--- a/src/gromacs/nblib/topology.h
+++ b/src/gromacs/nblib/topology.h
@@ -71,7 +71,9 @@ private:
     t_blocka createExclusionsList() const;
 
     template <class Extractor>
-    std::vector<real> extractQuantity(Extractor extractor);
+    std::vector<real> extractAtomTypeQuantity(Extractor extractor);
+
+    std::vector<real> extractCharge();
 };
 
 } // namespace nblib


### PR DESCRIPTION
…pesafe

Removes charge from AtomType and makes it a property set when adding atoms to
a molecule. Adding atoms to a molecule is now type safe. Added test for all
addAtom function signatures.