### PR TITLE
Sort includes and separate copyright from doxygen

### DIFF
--- a/src/gromacs/nblib/atoms.cpp
+++ b/src/gromacs/nblib/atoms.cpp
@@ -31,12 +31,17 @@
  *
  * To help us fund GROMACS development, we humbly ask that you cite
  * the research papers on the package. Check out http://www.gromacs.org.
+ */
+/*! \internal \file
+ * \brief
+ * Implements nblib AtomType
  *
  * \author Victor Holanda <victor.holanda@cscs.ch>
  * \author Joe Jordan <ejjordan@kth.se>
  * \author Prashanth Kanduri <kanduri@cscs.ch>
  * \author Sebastian Keller <keller@cscs.ch>
  */
+#include "gmxpre.h"
 
 #include "atoms.h"
 

--- a/src/gromacs/nblib/atoms.h
+++ b/src/gromacs/nblib/atoms.h
@@ -31,22 +31,26 @@
  *
  * To help us fund GROMACS development, we humbly ask that you cite
  * the research papers on the package. Check out http://www.gromacs.org.
+ */
+/*! \internal \file
+ * \brief
+ * Implements nblib AtomType
  *
  * \author Victor Holanda <victor.holanda@cscs.ch>
  * \author Joe Jordan <ejjordan@kth.se>
  * \author Prashanth Kanduri <kanduri@cscs.ch>
  * \author Sebastian Keller <keller@cscs.ch>
  */
-
 #ifndef GROMACS_ATOMS_H
 #define GROMACS_ATOMS_H
 
+#include <string>
 #include <tuple>
 #include <unordered_map>
-#include <string>
 #include <vector>
 
 #include "gromacs/math/vectypes.h"
+
 #include "interactions.h"
 
 class TopologyBuilder;

--- a/src/gromacs/nblib/box.cpp
+++ b/src/gromacs/nblib/box.cpp
@@ -31,16 +31,21 @@
  *
  * To help us fund GROMACS development, we humbly ask that you cite
  * the research papers on the package. Check out http://www.gromacs.org.
+ */
+/*! \internal \file
+ * \brief
+ * Implements nblib simulation box
  *
  * \author Victor Holanda <victor.holanda@cscs.ch>
  * \author Joe Jordan <ejjordan@kth.se>
  * \author Prashanth Kanduri <kanduri@cscs.ch>
  * \author Sebastian Keller <keller@cscs.ch>
  */
-
-#include "gromacs/utility/exceptions.h"
+#include "gmxpre.h"
 
 #include "box.h"
+
+#include "gromacs/utility/exceptions.h"
 
 namespace nblib {
 

--- a/src/gromacs/nblib/box.h
+++ b/src/gromacs/nblib/box.h
@@ -31,17 +31,21 @@
  *
  * To help us fund GROMACS development, we humbly ask that you cite
  * the research papers on the package. Check out http://www.gromacs.org.
+ */
+/*! \internal \file
+ * \brief
+ * Implements nblib simulation box
  *
  * \author Victor Holanda <victor.holanda@cscs.ch>
  * \author Joe Jordan <ejjordan@kth.se>
  * \author Prashanth Kanduri <kanduri@cscs.ch>
  * \author Sebastian Keller <keller@cscs.ch>
  */
-
 #ifndef GROMACS_BOX_H
 #define GROMACS_BOX_H
 
 #include <array>
+
 #include "gromacs/math/vectypes.h"
 
 namespace nblib

--- a/src/gromacs/nblib/coordinates.cpp
+++ b/src/gromacs/nblib/coordinates.cpp
@@ -31,12 +31,17 @@
  *
  * To help us fund GROMACS development, we humbly ask that you cite
  * the research papers on the package. Check out http://www.gromacs.org.
+ */
+/*! \internal \file
+ * \brief
+ * Implements nblib coordinate generation
  *
  * \author Victor Holanda <victor.holanda@cscs.ch>
  * \author Joe Jordan <ejjordan@kth.se>
  * \author Prashanth Kanduri <kanduri@cscs.ch>
  * \author Sebastian Keller <keller@cscs.ch>
  */
+#include "gmxpre.h"
 
 #include "coordinates.h"
 

--- a/src/gromacs/nblib/coordinates.h
+++ b/src/gromacs/nblib/coordinates.h
@@ -31,25 +31,25 @@
  *
  * To help us fund GROMACS development, we humbly ask that you cite
  * the research papers on the package. Check out http://www.gromacs.org.
+ */
+/*! \internal \file
+ * \brief
+ * Implements nblib coordinate generation
  *
  * \author Victor Holanda <victor.holanda@cscs.ch>
  * \author Joe Jordan <ejjordan@kth.se>
  * \author Prashanth Kanduri <kanduri@cscs.ch>
  * \author Sebastian Keller <keller@cscs.ch>
  */
-
 #ifndef GROMACS_COORDINATES_H
 #define GROMACS_COORDINATES_H
-
-
-#include "nbkerneloptions.h"
-
-#include "coords.h"
 
 #include "gromacs/math/vectypes.h"
 #include "gromacs/topology/block.h"
 #include "gromacs/utility/smalloc.h"
 
+#include "coords.h"
+#include "nbkerneloptions.h"
 
 namespace nblib {
 

--- a/src/gromacs/nblib/forcecalculator.cpp
+++ b/src/gromacs/nblib/forcecalculator.cpp
@@ -31,17 +31,22 @@
  *
  * To help us fund GROMACS development, we humbly ask that you cite
  * the research papers on the package. Check out http://www.gromacs.org.
+ */
+/*! \internal \file
+ * \brief
+ * Implements nblib ForceCalculator
  *
  * \author Victor Holanda <victor.holanda@cscs.ch>
  * \author Joe Jordan <ejjordan@kth.se>
  * \author Prashanth Kanduri <kanduri@cscs.ch>
  * \author Sebastian Keller <keller@cscs.ch>
  */
+#include "gmxpre.h"
 
 #include "forcecalculator.h"
-#include "integrator.h"
 
 #include "gromacs/gmxlib/nrnb.h"
+#include "gromacs/math/vec.h"
 #include "gromacs/mdtypes/enerdata.h"
 #include "gromacs/mdtypes/simulation_workload.h"
 #include "gromacs/nbnxm/pairlistset.h"
@@ -50,7 +55,7 @@
 #include "gromacs/pbcutil/pbc.h"
 #include "gromacs/simd/simd.h"
 
-#include "gromacs/math/vec.h"
+#include "integrator.h"
 
 
 namespace nblib {

--- a/src/gromacs/nblib/forcecalculator.h
+++ b/src/gromacs/nblib/forcecalculator.h
@@ -31,21 +31,24 @@
  *
  * To help us fund GROMACS development, we humbly ask that you cite
  * the research papers on the package. Check out http://www.gromacs.org.
+ */
+/*! \internal \file
+ * \brief
+ * Implements nblib ForceCalculator
  *
  * \author Victor Holanda <victor.holanda@cscs.ch>
  * \author Joe Jordan <ejjordan@kth.se>
  * \author Prashanth Kanduri <kanduri@cscs.ch>
  * \author Sebastian Keller <keller@cscs.ch>
  */
-
 #ifndef GROMACS_FORCECALCULATOR_H
 #define GROMACS_FORCECALCULATOR_H
 
 #include "gromacs/timing/cyclecounter.h"
 
-#include "nbkernelsystem.h"
-#include "nbkerneloptions.h"
 #include "nbkerneldef.h"
+#include "nbkerneloptions.h"
+#include "nbkernelsystem.h"
 
 namespace nblib {
 

--- a/src/gromacs/nblib/integrator.cpp
+++ b/src/gromacs/nblib/integrator.cpp
@@ -31,14 +31,20 @@
  *
  * To help us fund GROMACS development, we humbly ask that you cite
  * the research papers on the package. Check out http://www.gromacs.org.
+ */
+/*! \internal \file
+ * \brief
+ * Implements nblib integrator
  *
  * \author Victor Holanda <victor.holanda@cscs.ch>
  * \author Joe Jordan <ejjordan@kth.se>
  * \author Prashanth Kanduri <kanduri@cscs.ch>
  * \author Sebastian Keller <keller@cscs.ch>
  */
+#include "gmxpre.h"
 
 #include "integrator.h"
+
 #include "gromacs/pbcutil/pbc.h"
 
 namespace nblib {

--- a/src/gromacs/nblib/integrator.h
+++ b/src/gromacs/nblib/integrator.h
@@ -31,22 +31,25 @@
  *
  * To help us fund GROMACS development, we humbly ask that you cite
  * the research papers on the package. Check out http://www.gromacs.org.
+ */
+/*! \internal \file
+ * \brief
+ * Implements nblib integrator
  *
  * \author Victor Holanda <victor.holanda@cscs.ch>
  * \author Joe Jordan <ejjordan@kth.se>
  * \author Prashanth Kanduri <kanduri@cscs.ch>
  * \author Sebastian Keller <keller@cscs.ch>
  */
-
 #ifndef GROMACS_INTEGRATOR_H
 #define GROMACS_INTEGRATOR_H
 
 #include <vector>
 
-#include "nbkerneloptions.h"
-
 #include "gromacs/math/vectypes.h"
 #include "gromacs/nbnxm/nbnxm.h"
+
+#include "nbkerneloptions.h"
 
 namespace nblib {
 

--- a/src/gromacs/nblib/interactions.h
+++ b/src/gromacs/nblib/interactions.h
@@ -31,17 +31,23 @@
  *
  * To help us fund GROMACS development, we humbly ask that you cite
  * the research papers on the package. Check out http://www.gromacs.org.
+ */
+/*! \file
+ * \brief
+ * Implements nblib HarmonicType
  *
  * \author Victor Holanda <victor.holanda@cscs.ch>
  * \author Joe Jordan <ejjordan@kth.se>
  * \author Prashanth Kanduri <kanduri@cscs.ch>
  * \author Sebastian Keller <keller@cscs.ch>
  */
-
 #ifndef GROMACS_INTERACTIONS_H
 #define GROMACS_INTERACTIONS_H
 
 #include "gromacs/math/vectypes.h"
+
+namespace nblib
+{
 
 //! Type of interaction
 struct HarmonicType
@@ -54,5 +60,5 @@ struct HarmonicType
     //int atomJ;
 };
 
-
+} //namespace nblib
 #endif //GROMACS_INTERACTIONS_H

--- a/src/gromacs/nblib/molecules.cpp
+++ b/src/gromacs/nblib/molecules.cpp
@@ -31,16 +31,21 @@
  *
  * To help us fund GROMACS development, we humbly ask that you cite
  * the research papers on the package. Check out http://www.gromacs.org.
+ */
+/*! \internal \file
+ * \brief
+ * Implements nblib Molecule
  *
  * \author Victor Holanda <victor.holanda@cscs.ch>
  * \author Joe Jordan <ejjordan@kth.se>
  * \author Prashanth Kanduri <kanduri@cscs.ch>
  * \author Sebastian Keller <keller@cscs.ch>
  */
-
-#include <tuple>
+#include "gmxpre.h"
 
 #include "molecules.h"
+
+#include <tuple>
 
 namespace nblib {
 

--- a/src/gromacs/nblib/molecules.h
+++ b/src/gromacs/nblib/molecules.h
@@ -31,25 +31,28 @@
  *
  * To help us fund GROMACS development, we humbly ask that you cite
  * the research papers on the package. Check out http://www.gromacs.org.
+ */
+/*! \internal \file
+ * \brief
+ * Implements nblib Molecule
  *
  * \author Victor Holanda <victor.holanda@cscs.ch>
  * \author Joe Jordan <ejjordan@kth.se>
  * \author Prashanth Kanduri <kanduri@cscs.ch>
  * \author Sebastian Keller <keller@cscs.ch>
  */
-
 #ifndef GROMACS_MOLECULES_H
 #define GROMACS_MOLECULES_H
 
+#include <string>
 #include <tuple>
 #include <unordered_map>
-#include <string>
 #include <vector>
+
+#include "gromacs/math/vectypes.h"
 
 #include "atoms.h"
 #include "interactions.h"
-
-#include "gromacs/math/vectypes.h"
 
 class TopologyBuilder;
 

--- a/src/gromacs/nblib/nbkerneldef.h
+++ b/src/gromacs/nblib/nbkerneldef.h
@@ -31,13 +31,16 @@
  *
  * To help us fund GROMACS development, we humbly ask that you cite
  * the research papers on the package. Check out http://www.gromacs.org.
+ */
+/*! \internal \file
+ * \brief
+ * Implements nblib kernel types
  *
  * \author Victor Holanda <victor.holanda@cscs.ch>
  * \author Joe Jordan <ejjordan@kth.se>
  * \author Prashanth Kanduri <kanduri@cscs.ch>
  * \author Sebastian Keller <keller@cscs.ch>
  */
-
 #ifndef GROMACS_NBKERNELDEF_H
 #define GROMACS_NBKERNELDEF_H
 

--- a/src/gromacs/nblib/nbkerneloptions.cpp
+++ b/src/gromacs/nblib/nbkerneloptions.cpp
@@ -31,6 +31,10 @@
  *
  * To help us fund GROMACS development, we humbly ask that you cite
  * the research papers on the package. Check out http://www.gromacs.org.
+ */
+/*! \internal \file
+ * \brief
+ * Implements nblib kernel setup options
  *
  * \author Berk Hess <hess@kth.se>
  * \author Victor Holanda <victor.holanda@cscs.ch>
@@ -38,12 +42,9 @@
  * \author Prashanth Kanduri <kanduri@cscs.ch>
  * \author Sebastian Keller <keller@cscs.ch>
  */
-
 #include "gmxpre.h"
 
 #include "nbkerneloptions.h"
-// #include "integrator.h"
-// #include "forcecalculator.h"
 
 #include "gromacs/compat/optional.h"
 #include "gromacs/ewald/ewald_utils.h"
@@ -66,13 +67,11 @@
 #include "gromacs/pbcutil/ishift.h"
 #include "gromacs/pbcutil/mshift.h"
 #include "gromacs/pbcutil/pbc.h"
-#include "gromacs/simd/simd.h"
 #include "gromacs/timing/cyclecounter.h"
 #include "gromacs/topology/topology.h"
 #include "gromacs/utility/enumerationhelpers.h"
 #include "gromacs/utility/fatalerror.h"
 #include "gromacs/utility/logger.h"
-
 
 namespace nblib {
 

--- a/src/gromacs/nblib/nbkerneloptions.h
+++ b/src/gromacs/nblib/nbkerneloptions.h
@@ -31,6 +31,10 @@
  *
  * To help us fund GROMACS development, we humbly ask that you cite
  * the research papers on the package. Check out http://www.gromacs.org.
+ */
+/*! \internal \file
+ * \brief
+ * Implements nblib kernel setup options
  *
  * \author Berk Hess <hess@kth.se>
  * \author Victor Holanda <victor.holanda@cscs.ch>
@@ -38,16 +42,15 @@
  * \author Prashanth Kanduri <kanduri@cscs.ch>
  * \author Sebastian Keller <keller@cscs.ch>
  */
-
 #ifndef GROMACS_SETUP_H
 #define GROMACS_SETUP_H
 
+#include "gromacs/math/vectypes.h"
+#include "gromacs/mdtypes/forcerec.h"
+#include "gromacs/mdtypes/interaction_const.h"
+
 #include "nbkerneldef.h"
 #include "nbkernelsystem.h"
-
-#include "gromacs/math/vectypes.h"
-#include "gromacs/mdtypes/interaction_const.h"
-#include "gromacs/mdtypes/forcerec.h"
 
 namespace nblib {
 
@@ -89,7 +92,7 @@ struct NBKernelOptions
  * by the factor \p sizeFactor, which has to be a power of 2.
  * Timings can be printed to stdout.
  *
- * \param[in/out] system The atomic system to compute nonbonded forces for
+ * \param[in,out] system The atomic system to compute nonbonded forces for
  * \param[in] options How the benchmark will be run.
  * \param[in] printTimings Whether to print cycle counters
  */

--- a/src/gromacs/nblib/nbkernelsystem.cpp
+++ b/src/gromacs/nblib/nbkernelsystem.cpp
@@ -31,6 +31,10 @@
  *
  * To help us fund GROMACS development, we humbly ask that you cite
  * the research papers on the package. Check out http://www.gromacs.org.
+ */
+/*! \internal \file
+ * \brief
+ * Implements nblib kernel system
  *
  * \author Berk Hess <hess@kth.se>
  * \author Victor Holanda <victor.holanda@cscs.ch>
@@ -38,10 +42,9 @@
  * \author Prashanth Kanduri <kanduri@cscs.ch>
  * \author Sebastian Keller <keller@cscs.ch>
  */
+#include "gmxpre.h"
 
 #include "nbkernelsystem.h"
-
-#include "coordinates.h"
 
 #include "gromacs/math/vec.h"
 #include "gromacs/mdlib/dispersioncorrection.h"
@@ -51,6 +54,7 @@
 #include "gromacs/pbcutil/pbc.h"
 #include "gromacs/utility/fatalerror.h"
 
+#include "coordinates.h"
 
 namespace nblib
 {

--- a/src/gromacs/nblib/nbkernelsystem.h
+++ b/src/gromacs/nblib/nbkernelsystem.h
@@ -31,6 +31,10 @@
  *
  * To help us fund GROMACS development, we humbly ask that you cite
  * the research papers on the package. Check out http://www.gromacs.org.
+ */
+/*! \file
+ * \brief
+ * Implements nblib kernel system
  *
  * \author Berk Hess <hess@kth.se>
  * \author Victor Holanda <victor.holanda@cscs.ch>
@@ -38,7 +42,6 @@
  * \author Prashanth Kanduri <kanduri@cscs.ch>
  * \author Sebastian Keller <keller@cscs.ch>
  */
-
 #ifndef GROMACS_NBKERNELSYSTEM_H
 #define GROMACS_NBKERNELSYSTEM_H
 

--- a/src/gromacs/nblib/simulationstate.cpp
+++ b/src/gromacs/nblib/simulationstate.cpp
@@ -31,6 +31,10 @@
  *
  * To help us fund GROMACS development, we humbly ask that you cite
  * the research papers on the package. Check out http://www.gromacs.org.
+ */
+/*! \internal \file
+ * \brief
+ * Implements nblib SimulationState
  *
  * \author Berk Hess <hess@kth.se>
  * \author Victor Holanda <victor.holanda@cscs.ch>
@@ -38,11 +42,9 @@
  * \author Prashanth Kanduri <kanduri@cscs.ch>
  * \author Sebastian Keller <keller@cscs.ch>
  */
-
 #include "gmxpre.h"
 
 #include "simulationstate.h"
-#include "nbkernelsystem.h"
 
 #include <vector>
 
@@ -55,6 +57,7 @@
 #include "gromacs/utility/fatalerror.h"
 
 #include "coords.h"
+#include "nbkernelsystem.h"
 
 namespace nblib {
 

--- a/src/gromacs/nblib/simulationstate.h
+++ b/src/gromacs/nblib/simulationstate.h
@@ -31,6 +31,10 @@
  *
  * To help us fund GROMACS development, we humbly ask that you cite
  * the research papers on the package. Check out http://www.gromacs.org.
+ */
+/*! \inlibraryapi \file
+ * \brief
+ * Implements nblib SimulationState
  *
  * \author Berk Hess <hess@kth.se>
  * \author Victor Holanda <victor.holanda@cscs.ch>
@@ -38,19 +42,18 @@
  * \author Prashanth Kanduri <kanduri@cscs.ch>
  * \author Sebastian Keller <keller@cscs.ch>
  */
-
 #ifndef GROMACS_SIMULATIONSTATE_H
 #define GROMACS_SIMULATIONSTATE_H
 
 #include <vector>
 
 #include "gromacs/math/vectypes.h"
+#include "gromacs/nblib/util.h"
 #include "gromacs/topology/block.h"
 #include "gromacs/utility/smalloc.h"
 
 #include "box.h"
 #include "topology.h"
-#include "util.h"
 
 namespace nblib
 {

--- a/src/gromacs/nblib/tests/box.cpp
+++ b/src/gromacs/nblib/tests/box.cpp
@@ -43,9 +43,9 @@
  */
 #include "gmxpre.h"
 
-#include <cmath>
-
 #include "gromacs/nblib/box.h"
+
+#include <cmath>
 
 #include "testutils/refdata.h"
 #include "testutils/testasserts.h"

--- a/src/gromacs/nblib/tests/molecules.cpp
+++ b/src/gromacs/nblib/tests/molecules.cpp
@@ -32,7 +32,6 @@
  * To help us fund GROMACS development, we humbly ask that you cite
  * the research papers on the package. Check out http://www.gromacs.org.
  */
-
 /*! \internal \file
  * \brief
  * This implements molecule setup tests
@@ -42,12 +41,13 @@
  * \author Prashanth Kanduri <kanduri@cscs.ch>
  * \author Sebastian Keller <keller@cscs.ch>
  */
+#include "gmxpre.h"
 
 #include "gromacs/nblib/molecules.h"
 
-#include "testutils/testasserts.h"
-
 #include <iostream>
+
+#include "testutils/testasserts.h"
 
 namespace nblib {
 namespace test {

--- a/src/gromacs/nblib/tests/nblib.cpp
+++ b/src/gromacs/nblib/tests/nblib.cpp
@@ -45,12 +45,11 @@
 
 #include "gromacs/nblib/box.h"
 #include "gromacs/nblib/coords.h"
-#include "gromacs/nblib/nbkerneloptions.h"
 #include "gromacs/nblib/interactions.h"
-#include "gromacs/nblib/topology.h"
 #include "gromacs/nblib/molecules.h"
+#include "gromacs/nblib/nbkerneloptions.h"
 #include "gromacs/nblib/nbkernelsystem.h"
-#include "gromacs/nblib/box.h"
+#include "gromacs/nblib/topology.h"
 
 #include "testutils/refdata.h"
 #include "testutils/testasserts.h"

--- a/src/gromacs/nblib/tests/simstate.cpp
+++ b/src/gromacs/nblib/tests/simstate.cpp
@@ -41,18 +41,16 @@
  * \author Prashanth Kanduri <kanduri@cscs.ch>
  * \author Sebastian Keller <keller@cscs.ch>
  */
+#include "gmxpre.h"
 
 #include <vector>
 
-#include "gmxpre.h"
-
-#include "gromacs/nblib/box.h"
-#include "gromacs/nblib/nbkerneloptions.h"
-#include "gromacs/nblib/topology.h"
-#include "gromacs/nblib/molecules.h"
-#include "gromacs/nblib/simulationstate.h"
-
 #include "gromacs/math/vec.h"
+#include "gromacs/nblib/box.h"
+#include "gromacs/nblib/molecules.h"
+#include "gromacs/nblib/nbkerneloptions.h"
+#include "gromacs/nblib/simulationstate.h"
+#include "gromacs/nblib/topology.h"
 
 #include "testutils/testasserts.h"
 

--- a/src/gromacs/nblib/tests/topology.cpp
+++ b/src/gromacs/nblib/tests/topology.cpp
@@ -41,6 +41,7 @@
  * \author Prashanth Kanduri <kanduri@cscs.ch>
  * \author Sebastian Keller <keller@cscs.ch>
  */
+#include "gmxpre.h"
 
 #include "gromacs/nblib/topology.h"
 

--- a/src/gromacs/nblib/tests/util.cpp
+++ b/src/gromacs/nblib/tests/util.cpp
@@ -41,9 +41,12 @@
  * \author Prashanth Kanduri <kanduri@cscs.ch>
  * \author Sebastian Keller <keller@cscs.ch>
  */
-#include <vector>
+#include "gmxpre.h"
 
 #include "gromacs/nblib/util.h"
+
+#include <vector>
+
 #include "gromacs/math/vectypes.h"
 
 #include "testutils/testasserts.h"

--- a/src/gromacs/nblib/topology.cpp
+++ b/src/gromacs/nblib/topology.cpp
@@ -31,23 +31,26 @@
  *
  * To help us fund GROMACS development, we humbly ask that you cite
  * the research papers on the package. Check out http://www.gromacs.org.
+ */
+/*! \internal \file
+ * \brief
+ * Implements nblib Topology and TopologyBuilder
  *
  * \author Victor Holanda <victor.holanda@cscs.ch>
  * \author Joe Jordan <ejjordan@kth.se>
  * \author Prashanth Kanduri <kanduri@cscs.ch>
  * \author Sebastian Keller <keller@cscs.ch>
  */
-
-#include <vector>
-#include <array>
-
-#include "gromacs/topology/block.h"
-#include "gromacs/utility/smalloc.h"
+#include "gmxpre.h"
 
 #include "topology.h"
 
-#include "gromacs/topology/exclusionblocks.h"
+#include <array>
+#include <vector>
+
 #include "gromacs/topology/block.h"
+#include "gromacs/topology/exclusionblocks.h"
+#include "gromacs/utility/smalloc.h"
 
 namespace nblib {
 

--- a/src/gromacs/nblib/topology.h
+++ b/src/gromacs/nblib/topology.h
@@ -31,21 +31,25 @@
  *
  * To help us fund GROMACS development, we humbly ask that you cite
  * the research papers on the package. Check out http://www.gromacs.org.
+ */
+/*! \internal \file
+ * \brief
+ * Implements nblib Topology and TopologyBuilder
  *
  * \author Victor Holanda <victor.holanda@cscs.ch>
  * \author Joe Jordan <ejjordan@kth.se>
  * \author Prashanth Kanduri <kanduri@cscs.ch>
  * \author Sebastian Keller <keller@cscs.ch>
  */
+#ifndef GROMACS_TOPOLOGY_H
+#define GROMACS_TOPOLOGY_H
 
 #include <vector>
 
 #include "gromacs/math/vec.h"
 #include "gromacs/topology/block.h"
-#include "molecules.h"
 
-#ifndef GROMACS_TOPOLOGY_H
-#define GROMACS_TOPOLOGY_H
+#include "molecules.h"
 
 struct t_blocka;
 

--- a/src/gromacs/nblib/util.cpp
+++ b/src/gromacs/nblib/util.cpp
@@ -31,12 +31,17 @@
  *
  * To help us fund GROMACS development, we humbly ask that you cite
  * the research papers on the package. Check out http://www.gromacs.org.
+ */
+/*! \internal \file
+ * \brief
+ * Implements nblib utility functions
  *
  * \author Victor Holanda <victor.holanda@cscs.ch>
  * \author Joe Jordan <ejjordan@kth.se>
  * \author Prashanth Kanduri <kanduri@cscs.ch>
  * \author Sebastian Keller <keller@cscs.ch>
  */
+#include "gmxpre.h"
 
 #include "util.h"
 


### PR DESCRIPTION
Now it is possible to build the cmake check-source target without
errors. This is needed so that when doxygen for classes is
introduced it can be checked for correctness. Once CI is up for
nblib check-source will need to be part of that.