### PR TITLE
Added names for param types

### DIFF
--- a/src/gromacs/nblib/atoms.cpp
+++ b/src/gromacs/nblib/atoms.cpp
@@ -48,14 +48,14 @@
 namespace nblib {
 
 Atom::Atom() noexcept :
-  name_(""),
-  mass_(0),
-  charge_(0),
-  c6_(0),
-  c12_(0)
+  name_(AtomKindName("")),
+  mass_(AtomMass(0)),
+  charge_(AtomCharge(0)),
+  c6_(C6Param(0)),
+  c12_(C12Param(0))
 {}
 
-Atom::Atom(std::string atomName, real mass, real charge, real c6, real c12)
+Atom::Atom(AtomKindName atomName, AtomMass mass, AtomCharge charge, C6Param c6, C12Param c12)
 : name_(std::move(atomName)),
   mass_(mass),
   charge_(charge),
@@ -63,14 +63,14 @@ Atom::Atom(std::string atomName, real mass, real charge, real c6, real c12)
   c12_(c12)
 {}
 
-std::string Atom::name() const { return name_; }
+AtomKindName Atom::name() const { return name_; }
 
-real Atom::mass() const { return mass_; }
+AtomMass Atom::mass() const { return mass_; }
 
-real Atom::charge() const { return charge_; }
+AtomCharge Atom::charge() const { return charge_; }
 
-real Atom::c6() const { return c6_; }
+C6Param Atom::c6() const { return c6_; }
 
-real Atom::c12() const { return c12_; }
+C12Param Atom::c12() const { return c12_; }
 
 } // namespace nblib

--- a/src/gromacs/nblib/atoms.h
+++ b/src/gromacs/nblib/atoms.h
@@ -61,11 +61,11 @@ public:
 
     Atom() noexcept;
 
-    explicit Atom(AtomKindName atomName,
-                  AtomMass mass,
-                  AtomCharge charge,
-                  C6Param c6,
-                  C12Param c12);
+    Atom(AtomKindName atomName,
+         AtomMass mass,
+         AtomCharge charge,
+         C6Param c6,
+         C12Param c12);
 
     AtomKindName name() const;
 

--- a/src/gromacs/nblib/atoms.h
+++ b/src/gromacs/nblib/atoms.h
@@ -45,45 +45,44 @@
 #define GROMACS_ATOMS_H
 
 #include <string>
-#include <tuple>
-#include <unordered_map>
-#include <vector>
 
 #include "gromacs/math/vectypes.h"
 
-#include "interactions.h"
-
-class TopologyBuilder;
-
 namespace nblib
 {
+using AtomKindName = std::string;
+using AtomMass = real;
+using AtomCharge = real;
+using C6Param = real;
+using C12Param = real;
 
 class Atom {
 public:
+
     Atom() noexcept;
 
-    Atom(std::string atomName,
-             real mass,
-             real charge,
-             real c6,
-             real c12);
+    explicit Atom(AtomKindName atomName,
+                  AtomMass mass,
+                  AtomCharge charge,
+                  C6Param c6,
+                  C12Param c12);
 
-    std::string name() const;
+    AtomKindName name() const;
 
-    real mass() const;
+    AtomMass mass() const;
 
-    real charge() const;
+    AtomCharge charge() const;
 
-    real c6() const;
+    C6Param c6() const;
 
-    real c12() const;
+    C12Param c12() const;
 
 private:
-    std::string name_;
-    real mass_;
-    real charge_;
-    real c6_;
-    real c12_;
+    AtomKindName name_;
+    AtomMass mass_;
+    AtomCharge charge_;
+    C6Param c6_;
+    C12Param c12_;
 };
 
 } //namespace nblib

--- a/src/gromacs/nblib/molecules.h
+++ b/src/gromacs/nblib/molecules.h
@@ -64,7 +64,7 @@ using ResidueName = std::string;
 
 class Molecule {
 public:
-    explicit Molecule(MoleculeName moleculeName);
+    Molecule(MoleculeName moleculeName);
 
     Molecule& addAtom(const AtomName &atomName, const ResidueName &residueName, Atom const &atomType);
 

--- a/src/gromacs/nblib/molecules.h
+++ b/src/gromacs/nblib/molecules.h
@@ -58,14 +58,17 @@ class TopologyBuilder;
 
 namespace nblib
 {
+using MoleculeName = std::string;
+using AtomName = std::string;
+using ResidueName = std::string;
 
 class Molecule {
 public:
-    Molecule(std::string moleculeName);
+    explicit Molecule(MoleculeName moleculeName);
 
-    Molecule& addAtom(const std::string &atomName, const std::string &residueName, Atom const &atomType);
+    Molecule& addAtom(const AtomName &atomName, const ResidueName &residueName, Atom const &atomType);
 
-    Molecule& addAtom(const std::string &atomName, Atom const &atomType);
+    Molecule& addAtom(const AtomName &atomName, Atom const &atomType);
 
     void addHarmonicBond(HarmonicType harmonicBond);
 
@@ -74,7 +77,7 @@ public:
 
     void addExclusion(std::tuple<std::string, std::string> atom, std::tuple<std::string, std::string> atomToExclude);
 
-    void addExclusion(std::string atomName, std::string atomNameToExclude);
+    void addExclusion(AtomName atomName, AtomName atomNameToExclude);
 
     int numAtomsInMolecule() const;
 
@@ -92,9 +95,9 @@ private:
 
     std::vector<HarmonicType> harmonicInteractions_;
 
-    int atomNameAndResidueToIndex(std::tuple<std::string, std::string> atomResNameTuple);
+    int atomNameAndResidueToIndex(std::tuple<AtomName , ResidueName> atomResNameTuple);
 
-    void addAtomSelfExclusion(std::string atomName, std::string resName);
+    void addAtomSelfExclusion(AtomName atomName, ResidueName resName);
 
 };
 

--- a/src/gromacs/nblib/tests/atoms.cpp
+++ b/src/gromacs/nblib/tests/atoms.cpp
@@ -57,11 +57,11 @@ namespace nblib
 
 struct ArAtom
 {
-    std::string name = "Ar";
-    real mass = 1.0;
-    real charge = 0;
-    real c6 = 1;
-    real c12 = 1;
+    AtomName name = "Ar";
+    AtomMass mass = 1.0;
+    AtomCharge charge = 0;
+    C6Param c6 = 1;
+    C12Param c12 = 1;
 };
 
 TEST(NBlibTest, AtomNameCanBeConstructed)


### PR DESCRIPTION
However, the compiler is still deducing without explicitly casting.
They keyword explicit isn't preventing automatic conversion of
parameter types.

Another approach to do the same in PR #11