### PR TITLE
fixed Atom charge and improved exclusions

### DIFF
--- a/src/gromacs/nblib/atomtype.cpp
+++ b/src/gromacs/nblib/atomtype.cpp
@@ -9,15 +9,13 @@ namespace nblib {
 AtomType::AtomType() noexcept :
   name_(""),
   mass_(0),
-  charge_(0),
   c6_(0),
   c12_(0)
 {}
 
-AtomType::AtomType(std::string atomName, real mass, real charge, real c6, real c12)
+AtomType::AtomType(std::string atomName, real mass, real c6, real c12)
 : name_(std::move(atomName)),
   mass_(mass),
-  charge_(charge),
   c6_(c6),
   c12_(c12)
 {}
@@ -25,8 +23,6 @@ AtomType::AtomType(std::string atomName, real mass, real charge, real c6, real c
 std::string AtomType::name() const { return name_; }
 
 real AtomType::mass() const { return mass_; }
-
-real AtomType::charge() const { return charge_; }
 
 real AtomType::c6() const { return c6_; }
 

--- a/src/gromacs/nblib/atomtype.h
+++ b/src/gromacs/nblib/atomtype.h
@@ -24,15 +24,12 @@ public:
 
     AtomType(std::string atomName,
              real mass,
-             real charge,
              real c6,
              real c12);
 
     std::string name() const;
 
     real mass() const;
-
-    real charge() const;
 
     real c6() const;
 
@@ -41,7 +38,6 @@ public:
 private:
     std::string name_;
     real mass_;
-    real charge_;
     real c6_;
     real c12_;
 };

--- a/src/gromacs/nblib/molecules.cpp
+++ b/src/gromacs/nblib/molecules.cpp
@@ -31,12 +31,12 @@ void Molecule::addAtomSelfExclusion(std::string atomName, std::string resName)
     }
 }
 
-Molecule& Molecule::addAtom(const std::string &atomName, const std::string &residueName, AtomType const &atomType)
+Molecule& Molecule::addAtom(const AtomName& atomName, const ResidueName& residueName, const Charge& charge, AtomType const &atomType)
 {
-    // check whether we already have the atom type
-    if (!atomTypes_.count(atomType.name()))
+    // this check can only ensure that we don't use the same atomName twice, not that an (AtomType, charge) pair is not repeated
+    if (!atomTypes_.count(atomName))
     {
-        atomTypes_[atomName] = atomType;
+        atomTypes_[atomName] = std::make_tuple(atomType, charge);
     }
 
     atoms_.emplace_back(std::make_tuple(atomName, residueName));
@@ -45,9 +45,25 @@ Molecule& Molecule::addAtom(const std::string &atomName, const std::string &resi
     return *this;
 }
 
-Molecule& Molecule::addAtom(const std::string &atomName, AtomType const &atomType)
+Molecule& Molecule::addAtom(const AtomName& atomName, const ResidueName& residueName, AtomType const &atomType)
 {
-    addAtom(atomName, name_, atomType);
+    real charge = 0;
+    addAtom(atomName, residueName, charge, atomType);
+
+    return *this;
+}
+
+Molecule& Molecule::addAtom(const AtomName& atomName, const Charge& charge, AtomType const &atomType)
+{
+    addAtom(atomName, name_, charge, atomType);
+
+    return *this;
+}
+
+Molecule& Molecule::addAtom(const AtomName& atomName, const AtomType& atomType)
+{
+    real charge = 0;
+    addAtom(atomName, name_, charge, atomType);
 
     return *this;
 }

--- a/src/gromacs/nblib/molecules.cpp
+++ b/src/gromacs/nblib/molecules.cpp
@@ -48,35 +48,18 @@ namespace nblib {
 
 Molecule::Molecule(std::string moleculeName) : name_(std::move(moleculeName)) {}
 
-void Molecule::addAtomSelfExclusion(std::string atomName, std::string resName)
-{
-    bool found = false;
-    int atomIndex = atomNameAndResidueToIndex(std::make_tuple(atomName, resName));
-
-    for(auto &tuple : exclusions_)
-    {
-        bool found = false;
-        if(std::get<0>(tuple) == atomIndex) {
-            if(std::get<1>(tuple) == atomIndex) {
-                found = true;
-            }
-        }
-    }
-    if(!found) {
-        exclusions_.emplace_back(std::make_tuple(atomIndex, atomIndex));
-    }
-}
-
 Molecule& Molecule::addAtom(const AtomName& atomName, const ResidueName& residueName, const Charge& charge, AtomType const &atomType)
 {
-    // this check can only ensure that we don't use the same atomName twice, not that an (AtomType, charge) pair is not repeated
-    if (!atomTypes_.count(atomName))
+    if (!atomTypes_.count(atomType.name()))
     {
-        atomTypes_[atomName] = std::make_tuple(atomType, charge);
+        atomTypes_[atomType.name()] = atomType;
     }
 
-    atoms_.emplace_back(std::make_tuple(atomName, residueName));
-    addAtomSelfExclusion(atomName, residueName);
+    atoms_.emplace_back(AtomData{atomName, residueName, atomType.name(), charge});
+
+    //! Add self exclusion. We just added the atom, so we know its index and that the exclusion doesn't exist yet
+    std::size_t id = atoms_.size()-1;
+    exclusions_.emplace_back(std::make_tuple(id, id));
 
     return *this;
 }
@@ -114,25 +97,6 @@ void Molecule::addHarmonicBond(HarmonicType harmonicBond)
     harmonicInteractions_.push_back(harmonicBond);
 }
 
-
-int Molecule::atomNameAndResidueToIndex(std::tuple<std::string, std::string> atomResNameTuple)
-{
-    auto equal = [](auto tup1, auto tup2) { return (std::get<0>(tup1) == std::get<0>(tup2) and std::get<1>(tup1) == std::get<1>(tup2)); };
-
-    auto posIter = std::find_if(begin(atoms_), end(atoms_),
-        [&](std::tuple<std::string, std::string> & atomAndResName)
-        {
-            return equal(atomAndResName, atomResNameTuple);
-        });
-
-    if(posIter != end(atoms_)) {
-        return posIter - begin(atoms_);
-    } else {
-        // TODO throw exception
-        return -1;
-    }
-}
-
 void Molecule::addExclusion(const int atomIndex, const int atomIndexToExclude)
 {
     // We do not need to add exclusion in case the atom indexes are the same
@@ -145,18 +109,88 @@ void Molecule::addExclusion(const int atomIndex, const int atomIndexToExclude)
 
 void Molecule::addExclusion(std::tuple<std::string, std::string> atom, std::tuple<std::string, std::string> atomToExclude)
 {
-    auto atomNameIndex = atomNameAndResidueToIndex(atom);
-    auto atomToExcludeIndex = atomNameAndResidueToIndex(atomToExclude);
-
-    addExclusion(atomNameIndex, atomToExcludeIndex);
+    //! duplication for the swapped pair happens in getExclusions()
+    exclusionsByName_.emplace_back(std::make_tuple(std::get<0>(atom), std::get<1>(atom),
+                                                   std::get<0>(atomToExclude), std::get<1>(atomToExclude)));
 }
 
-void Molecule::addExclusion(std::string atomName, std::string atomNameToExclude)
+void Molecule::addExclusion(const std::string &atomName, const std::string &atomNameToExclude)
 {
-    auto atomNameIndex = atomNameAndResidueToIndex(std::make_tuple(atomName, name_));
-    auto atomToExcludeIndex = atomNameAndResidueToIndex(std::make_tuple(atomNameToExclude, name_));
+    addExclusion(std::make_tuple(atomName, name_), std::make_tuple(atomNameToExclude, name_));
+}
 
-    addExclusion(atomNameIndex, atomToExcludeIndex);
+std::vector<std::tuple<int, int>> Molecule::getExclusions() const
+{
+    //! tuples of (atomName, residueName, index)
+    std::vector<std::tuple<std::string, std::string, int>> indexKey;
+    indexKey.reserve(numAtomsInMolecule());
+
+    for (int i = 0; i < numAtomsInMolecule(); ++i)
+    {
+       indexKey.emplace_back(std::make_tuple(atoms_[i].atomName_, atoms_[i].residueName_, i));
+    }
+
+    std::sort(std::begin(indexKey), std::end(indexKey));
+
+    std::vector<std::tuple<int, int>> ret = exclusions_;
+    ret.reserve(exclusions_.size() + exclusionsByName_.size());
+
+    //! normal operator<, except ignore third element
+    auto sortKey = [](const auto &tup1, const auto &tup2)
+            {
+                if (std::get<0>(tup1) < std::get<0>(tup2))
+                    return true;
+                else
+                    return std::get<1>(tup1) < std::get<1>(tup2);
+            };
+
+    //! convert exclusions given by names to indices and append
+    for (auto& tup : exclusionsByName_)
+    {
+        const std::string &atomName1 = std::get<0>(tup);
+        const std::string &residueName1 = std::get<1>(tup);
+        const std::string &atomName2 = std::get<2>(tup);
+        const std::string &residueName2 = std::get<3>(tup);
+
+        //! look up first index (binary search)
+        auto it1 = std::lower_bound(std::begin(indexKey), std::end(indexKey),
+                                    std::make_tuple(atomName1, residueName2, 0),
+                                    sortKey);
+
+        //! make sure we have the (atomName,residueName) combo
+        if (it1 == std::end(indexKey) or std::get<0>(*it1) != atomName1
+                                      or std::get<1>(*it1) != residueName1)
+        { throw std::runtime_error((std::string("Atom ") += atomName1 + std::string(" in residue ") +=
+                                    residueName1 + std::string(" not found in list of atoms\n")).c_str()); }
+
+        int firstIndex = std::get<2>(*it1);
+
+        //! look up second index (binary search)
+        auto it2 = std::lower_bound(std::begin(indexKey), std::end(indexKey),
+                                    std::make_tuple(atomName2, residueName2, 0),
+                                    sortKey);
+
+        //! make sure we have the (atomName,residueName) combo
+        if (it2 == std::end(indexKey) or std::get<0>(*it2) != atomName2
+            or std::get<1>(*it2) != residueName2)
+        { throw std::runtime_error((std::string("Atom ") += atomName2 + std::string(" in residue ") +=
+                                    residueName2 + std::string(" not found in list of atoms\n")).c_str()); }
+
+        int secondIndex = std::get<2>(*it2);
+
+        ret.emplace_back(std::make_tuple(firstIndex, secondIndex));
+        ret.emplace_back(std::make_tuple(secondIndex, firstIndex));
+    }
+
+    std::sort(std::begin(ret), std::end(ret));
+
+    auto uniqueEnd = std::unique(std::begin(ret), std::end(ret));
+    if (uniqueEnd != std::end(ret)) {
+        printf("[nblib] Warning: exclusionList for molecule %s contained duplicates", name_.c_str());
+    }
+
+    ret.erase(uniqueEnd, std::end(ret));
+    return ret;
 }
 
 } // namespace nblib

--- a/src/gromacs/nblib/molecules.h
+++ b/src/gromacs/nblib/molecules.h
@@ -79,29 +79,39 @@ public:
 
     void addExclusion(std::tuple<std::string, std::string> atom, std::tuple<std::string, std::string> atomToExclude);
 
-    void addExclusion(std::string atomName, std::string atomNameToExclude);
+    void addExclusion(const std::string &atomName, const std::string &atomNameToExclude);
 
     int numAtomsInMolecule() const;
+
+    //! convert exclusions given by name to indices and unify with exclusions given by indices
+    //! returns a sorted vector containing no duplicates of atoms to exclude by indices
+    std::vector<std::tuple<int, int>> getExclusions() const;
 
     friend class TopologyBuilder;
 
 private:
     std::string name_;
 
+    struct AtomData {
+        std::string atomName_;
+        std::string residueName_;
+        std::string atomTypeName_;
+        real charge_;
+    };
+
     //! one entry per atom in molecule
-    std::vector<std::tuple<std::string, std::string>> atoms_;
+    std::vector<AtomData> atoms_;
 
     //! collection of distinct Atoms in molecule
-    std::unordered_map<std::string, std::tuple<AtomType, real>> atomTypes_;
+    std::unordered_map<std::string, AtomType> atomTypes_;
 
     std::vector<std::tuple<int, int>> exclusions_;
 
+    //! we cannot efficiently compute indices during the build-phase
+    //! so we delay the conversion until TopologyBuilder requests it
+    std::vector<std::tuple<std::string, std::string, std::string, std::string>> exclusionsByName_;
+
     std::vector<HarmonicType> harmonicInteractions_;
-
-    int atomNameAndResidueToIndex(std::tuple<std::string, std::string> atomResNameTuple);
-
-    void addAtomSelfExclusion(std::string atomName, std::string resName);
-
 };
 
 } //namespace nblib

--- a/src/gromacs/nblib/molecules.h
+++ b/src/gromacs/nblib/molecules.h
@@ -20,13 +20,21 @@ class TopologyBuilder;
 namespace nblib
 {
 
+using AtomName = std::string;
+using Charge = real;
+using ResidueName = std::string;
+
 class Molecule {
 public:
     Molecule(std::string moleculeName);
 
-    Molecule& addAtom(const std::string &atomName, const std::string &residueName, AtomType const &atomType);
+    Molecule& addAtom(const AtomName& atomName, const ResidueName& residueName, const Charge& charge, AtomType const &atomType);
 
-    Molecule& addAtom(const std::string &atomName, AtomType const &atomType);
+    Molecule& addAtom(const AtomName& atomName, const ResidueName& residueName, AtomType const &atomType);
+
+    Molecule& addAtom(const AtomName& atomName, const Charge& charge, AtomType const &atomType);
+
+    Molecule& addAtom(const AtomName& atomName, AtomType const &atomType);
 
     void addHarmonicBond(HarmonicType harmonicBond);
 
@@ -46,8 +54,9 @@ private:
 
     //! one entry per atom in molecule
     std::vector<std::tuple<std::string, std::string>> atoms_;
+
     //! collection of distinct Atoms in molecule
-    std::unordered_map<std::string, AtomType> atomTypes_;
+    std::unordered_map<std::string, std::tuple<AtomType, real>> atomTypes_;
 
     std::vector<std::tuple<int, int>> exclusions_;
 

--- a/src/gromacs/nblib/tests/atoms.cpp
+++ b/src/gromacs/nblib/tests/atoms.cpp
@@ -56,7 +56,6 @@ struct ArAtom
 {
     std::string name = "Ar";
     real mass = 1.0;
-    real charge = 0;
     real c6 = 1;
     real c12 = 1;
 };
@@ -64,35 +63,28 @@ struct ArAtom
 TEST(NBlibTest, AtomNameCanBeConstructed)
 {
     ArAtom arAtom;
-    AtomType argonAtom(arAtom.name, arAtom.mass, arAtom.charge, arAtom.c6, arAtom.c12);
+    AtomType argonAtom(arAtom.name, arAtom.mass, arAtom.c6, arAtom.c12);
     EXPECT_EQ(argonAtom.name(), arAtom.name);
 }
 
 TEST(NBlibTest, AtomMassCanBeConstructed)
 {
     ArAtom arAtom;
-    AtomType argonAtom(arAtom.name, arAtom.mass, arAtom.charge, arAtom.c6, arAtom.c12);
+    AtomType argonAtom(arAtom.name, arAtom.mass, arAtom.c6, arAtom.c12);
     EXPECT_EQ(argonAtom.mass(), arAtom.mass);
-}
-
-TEST(NBlibTest, AtomChargeCanBeConstructed)
-{
-    ArAtom arAtom;
-    AtomType argonAtom(arAtom.name, arAtom.mass, arAtom.charge, arAtom.c6, arAtom.c12);
-    EXPECT_EQ(argonAtom.charge(), arAtom.charge);
 }
 
 TEST(NBlibTest, AtomC6CanBeConstructed)
 {
     ArAtom arAtom;
-    AtomType argonAtom(arAtom.name, arAtom.mass, arAtom.charge, arAtom.c6, arAtom.c12);
+    AtomType argonAtom(arAtom.name, arAtom.mass, arAtom.c6, arAtom.c12);
     EXPECT_EQ(argonAtom.c6(), arAtom.c6);
 }
 
 TEST(NBlibTest, AtomC12CanBeConstructed)
 {
     ArAtom arAtom;
-    AtomType argonAtom(arAtom.name, arAtom.mass, arAtom.charge, arAtom.c6, arAtom.c12);
+    AtomType argonAtom(arAtom.name, arAtom.mass, arAtom.c6, arAtom.c12);
     EXPECT_EQ(argonAtom.c12(), arAtom.c12);
 }
 

--- a/src/gromacs/nblib/tests/molecules.cpp
+++ b/src/gromacs/nblib/tests/molecules.cpp
@@ -51,38 +51,51 @@ namespace nblib {
 namespace test {
 namespace {
 
-Molecule generateWaterMolecule()
+TEST(NBlibTest, CanConstructMoleculeWithoutChargeOrResidueName)
+{
+    AtomType Ar("Ar", 40, 1., 1.);
+    Molecule argon("Ar");
+    EXPECT_NO_THROW(argon.addAtom(AtomName("Ar"), Ar));
+}
+
+TEST(NBlibTest, CanConstructMoleculeWithChargeWithoutResidueName)
+{
+    AtomType Ar("Ar", 40, 1., 1.);
+    Molecule argon("Ar");
+    EXPECT_NO_THROW(argon.addAtom(AtomName("Ar"), Charge(0), Ar));
+}
+
+TEST(NBlibTest, CanConstructMoleculeWithoutChargeWithResidueName)
+{
+    AtomType Ar("Ar", 40, 1., 1.);
+    Molecule argon("Ar");
+    EXPECT_NO_THROW(argon.addAtom(AtomName("Ar"), ResidueName("ar2"), Ar));
+}
+
+TEST(NBlibTest, CanConstructMoleculeWithChargeWithResidueName)
+{
+    AtomType Ar("Ar", 40, 1., 1.);
+    Molecule argon("Ar");
+    EXPECT_NO_THROW(argon.addAtom(AtomName("Ar"),  ResidueName("ar2"), Charge(0), Ar));
+}
+
+TEST(NBlibTest, CanGetNumAtomsInMolecule)
 {
     //! Manually Create Molecule (Water)
 
     //! 1. Define Atom Type
-    AtomType Ow("Ow", 16, -0.6, 1., 1.);
-    AtomType Hw("Hw", 1, +0.3, 1., 1.);
-    AtomType Ar("Ar", 40, 0., 1., 1.);
+    AtomType Ow("Ow", 16, 1., 1.);
+    AtomType Hw("Hw", 1, 1., 1.);
 
     //! 2. Define Molecule
-
-    //! 2.1 Water
     Molecule water("water");
 
-    water.addAtom("Oxygen", Ow);
-    water.addAtom("H1", Hw);
+    water.addAtom("Oxygen", Charge(-0.6), Ow);
+    water.addAtom("H1", Charge(+0.3), Hw);
     water.addAtom("H2", Hw);
 
-    water.addHarmonicBond(HarmonicType{1, 2, "H1", "Oxygen"});
-    water.addHarmonicBond(HarmonicType{1, 2, "H2", "Oxygen"});
-
-    water.addExclusion("Oxygen", "H1");
-    water.addExclusion("Oxygen", "H2");
-    water.addExclusion("H1", "H2");
-
-    return water;
-}
-
-TEST(NBlibTest, numAtomsTest)
-{
-    auto water = generateWaterMolecule();
     auto numAtoms = water.numAtomsInMolecule();
+
     EXPECT_EQ(3, numAtoms);
 }
 

--- a/src/gromacs/nblib/tests/molecules.cpp
+++ b/src/gromacs/nblib/tests/molecules.cpp
@@ -102,6 +102,68 @@ TEST(NBlibTest, CanGetNumAtomsInMolecule)
     EXPECT_EQ(3, numAtoms);
 }
 
+TEST(NBlibTest, CanConstructExclusionListFromNames)
+{
+    //! Manually Create Molecule (Water)
+
+    //! 1. Define Atom Type
+    AtomType Ow("Ow", 16, 1., 1.);
+    AtomType Hw("Hw", 1, 1., 1.);
+
+    //! 2. Define Molecule
+    Molecule water("water");
+
+    water.addAtom("Oxygen", Charge(-0.6), Ow);
+    water.addAtom("H1", Charge(+0.3), Hw);
+    water.addAtom("H2", Charge(+0.3), Hw);
+
+    water.addExclusion("H1", "Oxygen");
+    water.addExclusion("H1", "H2");
+    water.addExclusion("H2", "Oxygen");
+
+    std::vector<std::tuple<int, int>> exclusions = water.getExclusions();
+
+    std::vector<std::tuple<int, int>> reference{ {0,0}, {0,1}, {0,2},
+                                                 {1,0}, {1,1}, {1,2},
+                                                 {2,0}, {2,1}, {2,2}};
+
+    ASSERT_EQ(exclusions.size(), 9);
+    for (std::size_t i = 0; i < exclusions.size(); ++i)
+        EXPECT_EQ(exclusions[i], reference[i]);
+
+}
+
+TEST(NBlibTest, CanConstructExclusionListFromNamesAndIndicesMixed)
+{
+    //! Manually Create Molecule (Water)
+
+    //! 1. Define Atom Type
+    AtomType Ow("Ow", 16, 1., 1.);
+    AtomType Hw("Hw", 1, 1., 1.);
+
+    //! 2. Define Molecule
+    Molecule water("water");
+
+    water.addAtom("Oxygen", Charge(-0.6), Ow);
+    water.addAtom("H1", Charge(+0.3), Hw);
+    water.addAtom("H2", Charge(+0.3), Hw);
+
+    water.addExclusion("H1", "Oxygen");
+    water.addExclusion("H1", "H2");
+    water.addExclusion(2, 0);
+
+    std::vector<std::tuple<int, int>> exclusions = water.getExclusions();
+
+    std::vector<std::tuple<int, int>> reference{ {0,0}, {0,1}, {0,2},
+                                                 {1,0}, {1,1}, {1,2},
+                                                 {2,0}, {2,1}, {2,2}};
+
+    ASSERT_EQ(exclusions.size(), 9);
+    for (std::size_t i = 0; i < exclusions.size(); ++i)
+        EXPECT_EQ(exclusions[i], reference[i]);
+
+}
+
 }  // namespace
 }  // namespace test
 }  // namespace nblib

--- a/src/gromacs/nblib/tests/simstate.cpp
+++ b/src/gromacs/nblib/tests/simstate.cpp
@@ -77,7 +77,7 @@ public:
     {
         constexpr int NumArgonAtoms = 3;
 
-        AtomType argonAtom("AR", 39.94800, 0.0, 0.0062647225, 9.847044e-06);
+        AtomType argonAtom("AR", 39.94800, 0.0062647225, 9.847044e-06);
 
         Molecule argonMolecule("AR");
         argonMolecule.addAtom("AR", argonAtom);

--- a/src/gromacs/nblib/topology.cpp
+++ b/src/gromacs/nblib/topology.cpp
@@ -45,11 +45,67 @@
 
 #include "atomtype.h"
 #include "topology.h"
+#include "util.h"
 
 #include "gromacs/topology/exclusionblocks.h"
 #include "gromacs/topology/block.h"
 
 namespace nblib {
+
+namespace detail {
+
+std::vector<gmx::ExclusionBlock> toGmxExclusionBlock(const std::vector<std::tuple<int, int>> &tupleList);
+std::vector<gmx::ExclusionBlock> offsetGmxBlock(std::vector<gmx::ExclusionBlock> inBlock, int offset);
+
+
+//! Converts tuples of atom indices to exclude to the gmx::ExclusionBlock format
+std::vector<gmx::ExclusionBlock> toGmxExclusionBlock(const std::vector<std::tuple<int, int>> &tupleList)
+{
+    std::vector<gmx::ExclusionBlock> ret;
+
+    //! initialize pair of iterators delimiting the range of exclusions for
+    //! the first atom in the list
+    GMX_ASSERT(!tupleList.empty(), "tupleList must not be empty\n");
+    auto range = std::equal_range(std::begin(tupleList), std::end(tupleList),
+                                  tupleList[0]);
+    auto it1 = range.first;
+    auto it2 = range.second;
+
+    //! loop over all exclusions in molecule, linear in tupleList.size()
+    while (it1 != std::end(tupleList))
+    {
+        gmx::ExclusionBlock localBlock;
+        //! loop over all exclusions for current atom
+        for ( ; it1 != it2; ++it1)
+        {
+            localBlock.atomNumber.push_back(std::get<1>(*it1));
+        }
+
+        ret.push_back(localBlock);
+
+        //! update the upper bound of the range for the next atom
+        if (it1 != end(tupleList))
+            it2 = std::upper_bound(it1, std::end(tupleList), *it1);
+    }
+
+    return ret;
+}
+
+//! add offset to all indices in inBlock
+std::vector<gmx::ExclusionBlock> offsetGmxBlock(std::vector<gmx::ExclusionBlock> inBlock, int offset)
+{
+    //! shift atom numbers by offset
+    for (auto& localBlock : inBlock)
+    {
+        std::transform(std::begin(localBlock.atomNumber), std::end(localBlock.atomNumber),
+                       std::begin(localBlock.atomNumber),
+                       [offset](auto i){ return i + offset; });
+    }
+
+    return inBlock;
+}
+
+} // namespace detail
 
 TopologyBuilder::TopologyBuilder() : numAtoms_(0)
 {}
@@ -61,66 +117,18 @@ t_blocka TopologyBuilder::createExclusionsList() const
     std::vector<gmx::ExclusionBlock> exclusionBlockGlobal;
     exclusionBlockGlobal.reserve(numAtoms_);
 
-    //! compare tuples by comparing the first element
-    auto firstLowerThan = [](auto tup1, auto tup2) { return std::get<0>(tup1) < std::get<0>(tup2); };
-
     size_t atomNumberOffset = 0;
     for (const auto &molNumberTuple : moleculesList)
     {
         const Molecule& molecule = std::get<0>(molNumberTuple);
         size_t numMols = std::get<1>(molNumberTuple);
 
-        std::vector<std::tuple<int, int>> exclusionList = molecule.exclusions_;
-
-        //! sorted (by first tuple element as key) list of exclusion pairs
-        std::sort(std::begin(exclusionList), std::end(exclusionList), firstLowerThan);
-
-        //! remove duplicates
-        auto unique_end = std::unique(std::begin(exclusionList), std::end(exclusionList));
-        if (unique_end != std::end(exclusionList))
-            printf("[nblib] Warning: exclusionList of molecule \"%s\" contained duplicates",
-                    molecule.name_.c_str());
-
-        exclusionList.erase(unique_end, std::end(exclusionList));
-
-        std::vector<gmx::ExclusionBlock> exclusionBlockPerMolecule;
-
-        //! initialize pair of iterators delimiting the range of exclusions for
-        //! the first atom in the list
-        GMX_ASSERT(!exclusionList.empty(), "exclusionList must not be empty\n");
-        auto range = std::equal_range(std::begin(exclusionList), std::end(exclusionList),
-                                  exclusionList[0], firstLowerThan);
-        auto it1 = range.first;
-        auto it2 = range.second;
-
-        //! loop over all exclusions in molecule, linear in exclusionList.size()
-        while (it1 != std::end(exclusionList))
-        {
-            gmx::ExclusionBlock localBlock;
-            //! loop over all exclusions for current atom
-            for ( ; it1 != it2; ++it1)
-            {
-                localBlock.atomNumber.push_back(std::get<1>(*it1));
-            }
-
-            exclusionBlockPerMolecule.push_back(localBlock);
-
-            //! update the upper bound of the range for the next atom
-            if (it1 != end(exclusionList))
-                it2 = std::upper_bound(it1, std::end(exclusionList), *it1, firstLowerThan);
-        }
+        std::vector<gmx::ExclusionBlock> exclusionBlockPerMolecule = detail::toGmxExclusionBlock(molecule.getExclusions());
 
         //! duplicate the exclusionBlockPerMolecule for the number of Molecules of (numMols)
         for (size_t i = 0; i < numMols; ++i)
         {
-            auto offsetExclusions = exclusionBlockPerMolecule;
-            //! shift atom numbers by atomNumberOffset
-            for (auto& localBlock : offsetExclusions)
-            {
-                std::transform(std::begin(localBlock.atomNumber), std::end(localBlock.atomNumber),
-                               std::begin(localBlock.atomNumber),
-                               [atomNumberOffset](auto i){ return i + atomNumberOffset; });
-            }
+            auto offsetExclusions = detail::offsetGmxBlock(exclusionBlockPerMolecule, atomNumberOffset);
 
             std::copy(std::begin(offsetExclusions), std::end(offsetExclusions),
                       std::back_inserter(exclusionBlockGlobal));
@@ -161,12 +169,9 @@ std::vector<real> TopologyBuilder::extractAtomTypeQuantity(Extractor extractor)
 
         for (size_t i = 0; i < numMols; ++i)
         {
-            for (auto &atomTuple : molecule.atoms_)
+            for (auto &atomData : molecule.atoms_)
             {
-                std::string atomTypeName = std::get<1>(atomTuple);
-
-                const auto &atcTup = molecule.atomTypes_[atomTypeName];
-                ret.push_back(extractor(atcTup));
+                ret.push_back(extractor(atomData, molecule.atomTypes_));
             }
         }
     }
@@ -177,13 +182,13 @@ std::vector<real> TopologyBuilder::extractAtomTypeQuantity(Extractor extractor)
 Topology TopologyBuilder::buildTopology()
 {
     topology_.excls = createExclusionsList();
-    topology_.masses = extractAtomTypeQuantity([](const auto &atcTup){ return std::get<0>(atcTup).mass(); });
-    topology_.charges = extractAtomTypeQuantity([](const auto &atcTup){ return std::get<1>(atcTup); });
+    topology_.masses = extractAtomTypeQuantity([](const auto &data, auto& map){ return map[data.atomTypeName_].mass(); });
+    topology_.charges = extractAtomTypeQuantity([](const auto &data, auto& map){ ignore_unused(map); return data.charge_; });
 
     return topology_;
 }
 
-TopologyBuilder& TopologyBuilder::addMolecule(const Molecule molecule, const int nMolecules)
+TopologyBuilder& TopologyBuilder::addMolecule(const Molecule &molecule, const int nMolecules)
 {
     /*!
      * 1. Push-back a tuple of molecule type and nMolecules

--- a/src/gromacs/nblib/topology.cpp
+++ b/src/gromacs/nblib/topology.cpp
@@ -78,7 +78,7 @@ t_blocka TopologyBuilder::createExclusionsList() const
 }
 
 template <class Extractor>
-std::vector<real> TopologyBuilder::extractQuantity(Extractor extractor)
+std::vector<real> TopologyBuilder::extractAtomTypeQuantity(Extractor extractor)
 {
     auto &moleculesList = molecules_;
 
@@ -97,8 +97,36 @@ std::vector<real> TopologyBuilder::extractQuantity(Extractor extractor)
             {
                 std::string atomTypeName = std::get<1>(atomTuple);
 
-                AtomType &atomType = molecule.atomTypes_[atomTypeName];
+                AtomType &atomType = std::get<0>(molecule.atomTypes_[atomTypeName]);
                 ret.push_back(extractor(atomType));
+            }
+        }
+    }
+
+    return ret;
+}
+
+std::vector<real> TopologyBuilder::extractCharge()
+{
+    auto &moleculesList = molecules_;
+
+    //! returned object
+    std::vector<real> ret;
+    ret.reserve(numAtoms_);
+
+    for (auto &molNumberTuple : moleculesList)
+    {
+        Molecule &molecule = std::get<0>(molNumberTuple);
+        size_t numMols = std::get<1>(molNumberTuple);
+
+        for (size_t i = 0; i < numMols; ++i)
+        {
+            for (auto &atomTuple : molecule.atoms_)
+            {
+                std::string atomTypeName = std::get<1>(atomTuple);
+
+                real charge = std::get<1>(molecule.atomTypes_[atomTypeName]);
+                ret.push_back(charge);
             }
         }
     }
@@ -109,8 +137,8 @@ std::vector<real> TopologyBuilder::extractQuantity(Extractor extractor)
 Topology TopologyBuilder::buildTopology()
 {
     topology_.excls = createExclusionsList();
-    topology_.masses = extractQuantity([](const AtomType &atomType){ return atomType.mass(); });
-    topology_.charges = extractQuantity([](const AtomType &atomType){ return atomType.charge(); });
+    topology_.masses = extractAtomTypeQuantity([](const AtomType &atomType){ return atomType.mass(); });
+    topology_.charges = extractCharge();
 
     return topology_;
 }

--- a/src/gromacs/nblib/topology.cpp
+++ b/src/gromacs/nblib/topology.cpp
@@ -165,36 +165,8 @@ std::vector<real> TopologyBuilder::extractAtomTypeQuantity(Extractor extractor)
             {
                 std::string atomTypeName = std::get<1>(atomTuple);
 
-                AtomType &atomType = std::get<0>(molecule.atomTypes_[atomTypeName]);
-                ret.push_back(extractor(atomType));
-            }
-        }
-    }
-
-    return ret;
-}
-
-std::vector<real> TopologyBuilder::extractCharge()
-{
-    auto &moleculesList = molecules_;
-
-    //! returned object
-    std::vector<real> ret;
-    ret.reserve(numAtoms_);
-
-    for (auto &molNumberTuple : moleculesList)
-    {
-        Molecule &molecule = std::get<0>(molNumberTuple);
-        size_t numMols = std::get<1>(molNumberTuple);
-
-        for (size_t i = 0; i < numMols; ++i)
-        {
-            for (auto &atomTuple : molecule.atoms_)
-            {
-                std::string atomTypeName = std::get<1>(atomTuple);
-
-                real charge = std::get<1>(molecule.atomTypes_[atomTypeName]);
-                ret.push_back(charge);
+                const auto &atcTup = molecule.atomTypes_[atomTypeName];
+                ret.push_back(extractor(atcTup));
             }
         }
     }
@@ -205,8 +177,8 @@ std::vector<real> TopologyBuilder::extractCharge()
 Topology TopologyBuilder::buildTopology()
 {
     topology_.excls = createExclusionsList();
-    topology_.masses = extractAtomTypeQuantity([](const AtomType &atomType){ return atomType.mass(); });
-    topology_.charges = extractCharge();
+    topology_.masses = extractAtomTypeQuantity([](const auto &atcTup){ return std::get<0>(atcTup).mass(); });
+    topology_.charges = extractAtomTypeQuantity([](const auto &atcTup){ return std::get<1>(atcTup); });
 
     return topology_;
 }

--- a/src/gromacs/nblib/topology.h
+++ b/src/gromacs/nblib/topology.h
@@ -71,7 +71,9 @@ private:
     t_blocka createExclusionsList() const;
 
     template <class Extractor>
-    std::vector<real> extractQuantity(Extractor extractor);
+    std::vector<real> extractAtomTypeQuantity(Extractor extractor);
+
+    std::vector<real> extractCharge();
 };
 
 } // namespace nblib

--- a/src/gromacs/nblib/topology.h
+++ b/src/gromacs/nblib/topology.h
@@ -96,7 +96,7 @@ public:
 
     Topology buildTopology();
 
-    TopologyBuilder& addMolecule(Molecule moleculeType, int nMolecules);
+    TopologyBuilder& addMolecule(const Molecule &moleculeType, int nMolecules);
 
 private:
     Topology topology_;
@@ -108,8 +108,6 @@ private:
 
     template <class Extractor>
     std::vector<real> extractAtomTypeQuantity(Extractor extractor);
-
-    std::vector<real> extractCharge();
 };
 
 } // namespace nblib

--- a/src/gromacs/nblib/util.h
+++ b/src/gromacs/nblib/util.h
@@ -53,6 +53,9 @@ std::vector<gmx::RVec> generateVelocity(real Temperature, unsigned int seed, std
 
 bool checkNumericValues(const std::vector<gmx::RVec> &values);
 
+template <class T>
+inline void ignore_unused(T& x) { static_cast<void>(x); }
+
 } // namespace nblib
 
 #endif //GROMACS_UTIL_H


### PR DESCRIPTION
Change-Id: Ic08cb23454ea5d5455e1130dd89554e9d057416b

This PR introduces two changes:

1) move Atom charge inside molecule into the per atom data structure atoms_; otherwise
it's not possible to specify different charges for atoms with the same name but in different residues.

2) previously, adding exclusions by (atomName,residueName) tuples scaled as O(MN) with
N=number of atoms and M=number of exclusions. This has now been reduced to O(MlogN).
To achieve this, conversion from name-based exclusions to index-based does not happen
until the Molecule::getExclusions() function is called. This function unifies all exclusions that
may have been specified as both named tuples or index tuples and returns a single list of index tuples. This change is transparent to TopologyBuilder::createExclusionsList, which therefore essentially remains unchanged (has been broken down into smaller functions).