### PR TITLE
Add getters and builders for AtomType name in TopologyBuilder

### DIFF
--- a/src/gromacs/nblib/tests/topology.cpp
+++ b/src/gromacs/nblib/tests/topology.cpp
@@ -99,19 +99,46 @@ public:
 
 TEST(NBlibTest, TopologyHasCharges)
 {
-    TwoWaterMolecules waters;
-    Topology          watersTopology = waters.buildTopology();
-    std::vector<real> test           = watersTopology.getCharges();
-    std::vector<real> ref            = { -0.6, 0.3, 0.3, -0.6, 0.3, 0.3 };
+    TwoWaterMolecules       waters;
+    Topology                watersTopology = waters.buildTopology();
+    const std::vector<real> test           = watersTopology.getCharges();
+    const std::vector<real> ref            = { -0.6, 0.3, 0.3, -0.6, 0.3, 0.3 };
     EXPECT_EQ(ref, test);
 }
 
 TEST(NBlibTest, TopologyHasMasses)
 {
+    TwoWaterMolecules       waters;
+    Topology                watersTopology = waters.buildTopology();
+    const std::vector<real> test           = watersTopology.getMasses();
+    const std::vector<real> ref            = { 16., 1., 1., 16., 1., 1. };
+    EXPECT_EQ(ref, test);
+}
+
+TEST(NBlibTest, TopologyHasAtomTypes)
+{
+    TwoWaterMolecules              waters;
+    Topology                       watersTopology = waters.buildTopology();
+    const std::vector<std::string> test           = watersTopology.getAtomTypes();
+    const std::vector<std::string> ref            = { "Ow", "Hw", "Hw", "Ow", "Hw", "Hw" };
+    EXPECT_EQ(ref, test);
+}
+
+TEST(NBlibTest, TopologyHasUniqueAtomTypes)
+{
+    TwoWaterMolecules              waters;
+    Topology                       watersTopology = waters.buildTopology();
+    const std::vector<std::string> test           = watersTopology.getUniqueAtomTypes();
+    const std::vector<std::string> ref            = { "Hw", "Ow" };
+    EXPECT_EQ(ref, test);
+}
+
+TEST(NBlibTest, TopologyHasCorrectNumberOfAtomTypes)
+{
     TwoWaterMolecules waters;
     Topology          watersTopology = waters.buildTopology();
-    std::vector<real> test           = watersTopology.getMasses();
-    std::vector<real> ref            = { 16., 1., 1., 16., 1., 1. };
+    const int         test           = watersTopology.numAtomTypes();
+    const int         ref            = 2; // "Hw", "Ow"
     EXPECT_EQ(ref, test);
 }
 

--- a/src/gromacs/nblib/topology.h
+++ b/src/gromacs/nblib/topology.h
@@ -79,7 +79,14 @@ std::vector<gmx::ExclusionBlock> offsetGmxBlock(std::vector<gmx::ExclusionBlock>
 class Topology
 {
 public:
-    const std::vector<int>& getAtoms() const;
+    //! The number of unique AtomType names
+    int numAtomTypes() const;
+
+    //! Returns a vector of atom names
+    const std::vector<std::string>& getAtomTypes() const;
+
+    //! Returns a vector of sorted atom names without duplicates
+    const std::vector<std::string>& getUniqueAtomTypes() const;
 
     //! Returns a vector of atom partial charges
     const std::vector<real>& getCharges() const;
@@ -103,7 +110,9 @@ private:
     //! Storage for parameters for short range interactions.
     std::vector<real> nonbondedParameters_;
     //! Storage for atom type parameters.
-    std::vector<int> atomTypes_;
+    std::vector<std::string> atomTypes_;
+    //! Storage for atom type parameters but without duplicates and sorted.
+    std::vector<std::string> uniqueAtomTypes_;
     //! Storage for atom partial charges.
     std::vector<real> charges_;
     //! Atom masses
@@ -122,7 +131,8 @@ private:
  * topologies only exist in a valid state within the scope of the
  * simulation program.
  */
-class TopologyBuilder {
+class TopologyBuilder
+{
 public:
     //! Constructor
     TopologyBuilder();
@@ -152,8 +162,8 @@ private:
     t_blocka createExclusionsList() const;
 
     //! Helper function to extract quantities like mass, charge, etc from the system
-    template <class Extractor>
-    std::vector<real> extractAtomTypeQuantity(Extractor extractor);
+    template<typename T, class Extractor>
+    std::vector<T> extractAtomTypeQuantity(Extractor extractor);
 };
 
 } // namespace nblib


### PR DESCRIPTION
With this change it is now possible to get the number and type
of atoms in a Topology. This will be needed for building the
nonbondedParameters_ object. Tests are also added, as well as
some const correctness and formatting niceness in topology
tests.