### PR TITLE
Force explicit types in AtomType and Molecule ctors

### DIFF
--- a/src/gromacs/nblib/atomtype.cpp
+++ b/src/gromacs/nblib/atomtype.cpp
@@ -1,31 +1,68 @@
-//
-// Created by sebkelle on 20.11.19.
-//
+/*
+ * This file is part of the GROMACS molecular simulation package.
+ *
+ * Copyright (c) 2019, by the GROMACS development team, led by
+ * Mark Abraham, David van der Spoel, Berk Hess, and Erik Lindahl,
+ * and including many others, as listed in the AUTHORS file in the
+ * top-level source directory and at http://www.gromacs.org.
+ *
+ * GROMACS is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * GROMACS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with GROMACS; if not, see
+ * http://www.gnu.org/licenses, or write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
+ *
+ * If you want to redistribute modifications to GROMACS, please
+ * consider that scientific software is very special. Version
+ * control is crucial - bugs must be traceable. We will be happy to
+ * consider code for inclusion in the official distribution, but
+ * derived work must not be called official GROMACS. Details are found
+ * in the README & COPYING files - if they are missing, get the
+ * official version at http://www.gromacs.org.
+ *
+ * To help us fund GROMACS development, we humbly ask that you cite
+ * the research papers on the package. Check out http://www.gromacs.org.
+ */
+/*! \internal \file
+ * \brief
+ * Implements nblib AtomType
+ *
+ * \author Victor Holanda <victor.holanda@cscs.ch>
+ * \author Joe Jordan <ejjordan@kth.se>
+ * \author Prashanth Kanduri <kanduri@cscs.ch>
+ * \author Sebastian Keller <keller@cscs.ch>
+ */
 
 #include "atomtype.h"
 
-namespace nblib {
+namespace nblib
+{
 
-AtomType::AtomType() noexcept :
-  name_(""),
-  mass_(0),
-  c6_(0),
-  c12_(0)
-{}
+AtomType::AtomType() noexcept : name_(AtomName("")), mass_(Mass(0)), c6_(C6(0)), c12_(C12(0)) {}
 
-AtomType::AtomType(std::string atomName, real mass, real c6, real c12)
-: name_(std::move(atomName)),
-  mass_(mass),
-  c6_(c6),
-  c12_(c12)
-{}
+AtomType::AtomType(AtomName atomName, Mass mass, C6 c6, C12 c12) :
+    name_(std::move(atomName)),
+    mass_(mass),
+    c6_(c6),
+    c12_(c12)
+{
+}
 
-std::string AtomType::name() const { return name_; }
+AtomName AtomType::name() const { return name_; }
 
-real AtomType::mass() const { return mass_; }
+Mass AtomType::mass() const { return mass_; }
 
-real AtomType::c6() const { return c6_; }
+C6 AtomType::c6() const { return c6_; }
 
-real AtomType::c12() const { return c12_; }
+C12 AtomType::c12() const { return c12_; }
 
 } // namespace nblib

--- a/src/gromacs/nblib/atomtype.h
+++ b/src/gromacs/nblib/atomtype.h
@@ -58,28 +58,44 @@ class TopologyBuilder;
 namespace nblib
 {
 
-class AtomType {
+using AtomName = std::string;
+using Mass     = real;
+using C6       = real;
+using C12      = real;
+
+class AtomType
+{
 public:
     AtomType() noexcept;
 
-    AtomType(std::string atomName,
-             real mass,
-             real c6,
-             real c12);
+    //! Constructor with explicit type specification
+    AtomType(AtomName atomName, Mass mass, C6 c6, C12 c12);
 
-    std::string name() const;
+    //! Force explicit use of correct types
+    template<typename T, typename U, typename V, typename W>
+    AtomType(T atomName, U mass, V c6, W c12) = delete;
 
-    real mass() const;
+    //! Get the name
+    AtomName name() const;
 
-    real c6() const;
+    //! Get the mass
+    Mass mass() const;
 
-    real c12() const;
+    //! Get the c6 param
+    C6 c6() const;
+
+    //! Get the c12 param
+    C12 c12() const;
 
 private:
-    std::string name_;
-    real mass_;
-    real c6_;
-    real c12_;
+    //! The name
+    AtomName name_;
+    //! The mass
+    Mass mass_;
+    //! The c12 param
+    C6 c6_;
+    //! The c12 param
+    C12 c12_;
 };
 
 } //namespace nblib

--- a/src/gromacs/nblib/molecules.h
+++ b/src/gromacs/nblib/molecules.h
@@ -59,31 +59,56 @@ class TopologyBuilder;
 namespace nblib
 {
 
-using AtomName = std::string;
-using Charge = real;
+using AtomName    = std::string;
+using Charge      = real;
 using ResidueName = std::string;
 
-class Molecule {
+class Molecule
+{
 public:
+    //! Constructor
     Molecule(std::string moleculeName);
 
-    Molecule& addAtom(const AtomName& atomName, const ResidueName& residueName, const Charge& charge, AtomType const &atomType);
+    //! Add an atom to the molecule with full specification of parameters
+    Molecule& addAtom(const AtomName&    atomName,
+                      const ResidueName& residueName,
+                      const Charge&      charge,
+                      AtomType const&    atomType);
 
-    Molecule& addAtom(const AtomName& atomName, const ResidueName& residueName, AtomType const &atomType);
+    //! Force explicit use of correct types
+    template<typename T, typename U, typename V>
+    Molecule& addAtom(const T& atomName, const U& residueName, const V& charge, AtomType const& atomType) = delete;
 
-    Molecule& addAtom(const AtomName& atomName, const Charge& charge, AtomType const &atomType);
+    //! Add an atom to the molecule with implicit charge of 0
+    Molecule& addAtom(const AtomName& atomName, const ResidueName& residueName, AtomType const& atomType);
 
-    Molecule& addAtom(const AtomName& atomName, AtomType const &atomType);
+    //! Add an atom to the molecule with residueName set using atomName
+    Molecule& addAtom(const AtomName& atomName, const Charge& charge, AtomType const& atomType);
+
+    //! Force explicit use of correct types, covers both implicit charge and residueName
+    template<typename T, typename U>
+    Molecule& addAtom(const T& atomName, const U& charge, AtomType const& atomType) = delete;
+
+    //! Add an atom to the molecule with residueName set using atomName with implicit charge of 0
+    Molecule& addAtom(const AtomName& atomName, AtomType const& atomType);
+
+    //! Force explicit use of correct types
+    template<typename T>
+    Molecule& addAtom(const T& atomName, AtomType const& atomType) = delete;
 
     void addHarmonicBond(HarmonicType harmonicBond);
 
     // TODO: add exclusions based on the unique ID given to the atom of the molecule
     void addExclusion(const int atomIndex, const int atomIndexToExclude);
 
-    void addExclusion(std::tuple<std::string, std::string> atom, std::tuple<std::string, std::string> atomToExclude);
+    //! Specify an exclusion with atom and residue names that have been added to molecule
+    void addExclusion(std::tuple<std::string, std::string> atom,
+                      std::tuple<std::string, std::string> atomToExclude);
 
-    void addExclusion(const std::string &atomName, const std::string &atomNameToExclude);
+    //! Specify an exclusion with atoms names that have been added to molecule
+    void addExclusion(const std::string& atomName, const std::string& atomNameToExclude);
 
+    //! The number of molecules
     int numAtomsInMolecule() const;
 
     //! convert exclusions given by name to indices and unify with exclusions given by indices
@@ -93,13 +118,15 @@ public:
     friend class TopologyBuilder;
 
 private:
+    //! Name of the molecule
     std::string name_;
 
-    struct AtomData {
+    struct AtomData
+    {
         std::string atomName_;
         std::string residueName_;
         std::string atomTypeName_;
-        real charge_;
+        real        charge_;
     };
 
     //! one entry per atom in molecule
@@ -108,6 +135,7 @@ private:
     //! collection of distinct Atoms in molecule
     std::unordered_map<std::string, AtomType> atomTypes_;
 
+    //! Used for calculated exclusions based on atom indices in molecule
     std::vector<std::tuple<int, int>> exclusions_;
 
     //! we cannot efficiently compute indices during the build-phase

--- a/src/gromacs/nblib/tests/atoms.cpp
+++ b/src/gromacs/nblib/tests/atoms.cpp
@@ -57,36 +57,36 @@ namespace nblib
 
 struct ArAtom
 {
-    std::string name = "Ar";
-    real mass = 1.0;
-    real c6 = 1;
-    real c12 = 1;
+    AtomName name = "Ar";
+    Mass     mass = 1.0;
+    C6       c6   = 1;
+    C12      c12  = 1;
 };
 
 TEST(NBlibTest, AtomNameCanBeConstructed)
 {
-    ArAtom arAtom;
+    ArAtom   arAtom;
     AtomType argonAtom(arAtom.name, arAtom.mass, arAtom.c6, arAtom.c12);
     EXPECT_EQ(argonAtom.name(), arAtom.name);
 }
 
 TEST(NBlibTest, AtomMassCanBeConstructed)
 {
-    ArAtom arAtom;
+    ArAtom   arAtom;
     AtomType argonAtom(arAtom.name, arAtom.mass, arAtom.c6, arAtom.c12);
     EXPECT_EQ(argonAtom.mass(), arAtom.mass);
 }
 
 TEST(NBlibTest, AtomC6CanBeConstructed)
 {
-    ArAtom arAtom;
+    ArAtom   arAtom;
     AtomType argonAtom(arAtom.name, arAtom.mass, arAtom.c6, arAtom.c12);
     EXPECT_EQ(argonAtom.c6(), arAtom.c6);
 }
 
 TEST(NBlibTest, AtomC12CanBeConstructed)
 {
-    ArAtom arAtom;
+    ArAtom   arAtom;
     AtomType argonAtom(arAtom.name, arAtom.mass, arAtom.c6, arAtom.c12);
     EXPECT_EQ(argonAtom.c12(), arAtom.c12);
 }

--- a/src/gromacs/nblib/tests/molecules.cpp
+++ b/src/gromacs/nblib/tests/molecules.cpp
@@ -54,32 +54,60 @@ namespace nblib {
 namespace test {
 namespace {
 
+struct ArAtom
+{
+    AtomName name = "Ar";
+    Mass     mass = 1.0;
+    C6       c6   = 1;
+    C12      c12  = 1;
+};
+
+struct OwAtom
+{
+    AtomName name = "Ow";
+    Mass     mass = 16;
+    C6       c6   = 1.;
+    C12      c12  = 1.;
+};
+
+struct HwAtom
+{
+    AtomName name = "Hw";
+    Mass     mass = 1;
+    C6       c6   = 1.;
+    C12      c12  = 1.;
+};
+
 TEST(NBlibTest, CanConstructMoleculeWithoutChargeOrResidueName)
 {
-    AtomType Ar("Ar", 40, 1., 1.);
+    ArAtom   arAtom;
+    AtomType Ar(arAtom.name, arAtom.mass, arAtom.c6, arAtom.c12);
     Molecule argon("Ar");
     EXPECT_NO_THROW(argon.addAtom(AtomName("Ar"), Ar));
 }
 
 TEST(NBlibTest, CanConstructMoleculeWithChargeWithoutResidueName)
 {
-    AtomType Ar("Ar", 40, 1., 1.);
+    ArAtom   arAtom;
+    AtomType Ar(arAtom.name, arAtom.mass, arAtom.c6, arAtom.c12);
     Molecule argon("Ar");
     EXPECT_NO_THROW(argon.addAtom(AtomName("Ar"), Charge(0), Ar));
 }
 
 TEST(NBlibTest, CanConstructMoleculeWithoutChargeWithResidueName)
 {
-    AtomType Ar("Ar", 40, 1., 1.);
+    ArAtom   arAtom;
+    AtomType Ar(arAtom.name, arAtom.mass, arAtom.c6, arAtom.c12);
     Molecule argon("Ar");
     EXPECT_NO_THROW(argon.addAtom(AtomName("Ar"), ResidueName("ar2"), Ar));
 }
 
 TEST(NBlibTest, CanConstructMoleculeWithChargeWithResidueName)
 {
-    AtomType Ar("Ar", 40, 1., 1.);
+    ArAtom   arAtom;
+    AtomType Ar(arAtom.name, arAtom.mass, arAtom.c6, arAtom.c12);
     Molecule argon("Ar");
-    EXPECT_NO_THROW(argon.addAtom(AtomName("Ar"),  ResidueName("ar2"), Charge(0), Ar));
+    EXPECT_NO_THROW(argon.addAtom(AtomName("Ar"), ResidueName("ar2"), Charge(0), Ar));
 }
 
 TEST(NBlibTest, CanGetNumAtomsInMolecule)
@@ -87,15 +115,17 @@ TEST(NBlibTest, CanGetNumAtomsInMolecule)
     //! Manually Create Molecule (Water)
 
     //! 1. Define Atom Type
-    AtomType Ow("Ow", 16, 1., 1.);
-    AtomType Hw("Hw", 1, 1., 1.);
+    OwAtom   owAtom;
+    AtomType Ow(owAtom.name, owAtom.mass, owAtom.c6, owAtom.c12);
+    HwAtom   hwAtom;
+    AtomType Hw(hwAtom.name, hwAtom.mass, hwAtom.c6, hwAtom.c12);
 
     //! 2. Define Molecule
     Molecule water("water");
 
-    water.addAtom("Oxygen", Charge(-0.6), Ow);
-    water.addAtom("H1", Charge(+0.3), Hw);
-    water.addAtom("H2", Hw);
+    water.addAtom(AtomName("Oxygen"), Charge(-0.6), Ow);
+    water.addAtom(AtomName("H1"), Charge(+0.3), Hw);
+    water.addAtom(AtomName("H2"), Hw);
 
     auto numAtoms = water.numAtomsInMolecule();
 
@@ -107,15 +137,17 @@ TEST(NBlibTest, CanConstructExclusionListFromNames)
     //! Manually Create Molecule (Water)
 
     //! 1. Define Atom Type
-    AtomType Ow("Ow", 16, 1., 1.);
-    AtomType Hw("Hw", 1, 1., 1.);
+    OwAtom   owAtom;
+    AtomType Ow(owAtom.name, owAtom.mass, owAtom.c6, owAtom.c12);
+    HwAtom   hwAtom;
+    AtomType Hw(hwAtom.name, hwAtom.mass, hwAtom.c6, hwAtom.c12);
 
     //! 2. Define Molecule
     Molecule water("water");
 
-    water.addAtom("Oxygen", Charge(-0.6), Ow);
-    water.addAtom("H1", Charge(+0.3), Hw);
-    water.addAtom("H2", Charge(+0.3), Hw);
+    water.addAtom(AtomName("Oxygen"), Charge(-0.6), Ow);
+    water.addAtom(AtomName("H1"), Charge(+0.3), Hw);
+    water.addAtom(AtomName("H2"), Charge(+0.3), Hw);
 
     water.addExclusion("H1", "Oxygen");
     water.addExclusion("H1", "H2");
@@ -138,15 +170,17 @@ TEST(NBlibTest, CanConstructExclusionListFromNamesAndIndicesMixed)
     //! Manually Create Molecule (Water)
 
     //! 1. Define Atom Type
-    AtomType Ow("Ow", 16, 1., 1.);
-    AtomType Hw("Hw", 1, 1., 1.);
+    OwAtom   owAtom;
+    AtomType Ow(owAtom.name, owAtom.mass, owAtom.c6, owAtom.c12);
+    HwAtom   hwAtom;
+    AtomType Hw(hwAtom.name, hwAtom.mass, hwAtom.c6, hwAtom.c12);
 
     //! 2. Define Molecule
     Molecule water("water");
 
-    water.addAtom("Oxygen", Charge(-0.6), Ow);
-    water.addAtom("H1", Charge(+0.3), Hw);
-    water.addAtom("H2", Charge(+0.3), Hw);
+    water.addAtom(AtomName("Oxygen"), Charge(-0.6), Ow);
+    water.addAtom(AtomName("H1"), Charge(+0.3), Hw);
+    water.addAtom(AtomName("H2"), Charge(+0.3), Hw);
 
     water.addExclusion("H1", "Oxygen");
     water.addExclusion("H1", "H2");

--- a/src/gromacs/nblib/tests/topology.cpp
+++ b/src/gromacs/nblib/tests/topology.cpp
@@ -65,16 +65,16 @@ public:
         //! Manually Create Molecule (Water)
 
         //! Define Atom Type
-        AtomType Ow("Ow", 16, 1., 1.);
-        AtomType Hw("Hw", 1, 1., 1.);
+        AtomType Ow(AtomName("Ow"), Mass(16), C6(1.), C12(1.));
+        AtomType Hw(AtomName("Hw"), Mass(1), C6(1.), C12(1.));
 
         //! Define Molecule
         Molecule water("water");
 
         //! Add the atoms
-        water.addAtom("Oxygen", Charge(-0.6), Ow);
-        water.addAtom("H1", Charge(+0.3), Hw);
-        water.addAtom("H2", Charge(+0.3), Hw);
+        water.addAtom(AtomName("Oxygen"), Charge(-0.6), Ow);
+        water.addAtom(AtomName("H1"), Charge(+0.3), Hw);
+        water.addAtom(AtomName("H2"), Charge(+0.3), Hw);
 
         //! Add the exclusions
         water.addExclusion("Oxygen", "H1");


### PR DESCRIPTION
Now the caller must use the correct type when constructing AtomType
or Molecule objects. Also added doxygen, updated related tests,
made formatting a bit nicer, and added copyright header.