### PR TITLE
Make clang-format (mostly) happy

### DIFF
--- a/src/gromacs/nblib/atomtype.h
+++ b/src/gromacs/nblib/atomtype.h
@@ -55,10 +55,9 @@
 
 #include "interactions.h"
 
-class TopologyBuilder;
-
 namespace nblib
 {
+class TopologyBuilder;
 
 using AtomName = std::string;
 using Mass     = real;

--- a/src/gromacs/nblib/forcecalculator.cpp
+++ b/src/gromacs/nblib/forcecalculator.cpp
@@ -82,7 +82,7 @@ static real combinationFunction(real v, real w, CombinationRule combinationRule)
 {
     if (combinationRule == CombinationRule::Geometric)
     {
-        return sqrt(v * w);
+        return std::sqrt(v * w);
     }
     else
     {
@@ -243,7 +243,7 @@ void ForceCalculator::unpackTopologyToGmx()
 //! Sets up and runs the kernel calls
 //! TODO Refactor this function to return a handle to dispatchNonbondedKernel
 //!      that callers can manipulate directly.
-gmx::PaddedHostVector<gmx::RVec> ForceCalculator::compute(const bool printTimings)
+gmx::PaddedHostVector<gmx::RVec> ForceCalculator::compute()
 {
     // We set the interaction cut-off to the pairlist cut-off
     interaction_const_t ic   = setupInteractionConst(options_);
@@ -261,7 +261,7 @@ gmx::PaddedHostVector<gmx::RVec> ForceCalculator::compute(const bool printTiming
     std::unique_ptr<nonbonded_verlet_t> nbv = setupNbnxmInstance();
     // const PairlistSet& pairlistSet = nbv->pairlistSets().pairlistSet(gmx::InteractionLocality::Local);
     // const gmx::index numPairs = pairlistSet.natpair_ljq_ + pairlistSet.natpair_lj_ + pairlistSet.natpair_q_;
-    gmx_cycles_t cycles = gmx_cycles_read();
+    // gmx_cycles_t cycles = gmx_cycles_read();
 
     t_forcerec forceRec;
     forceRec.ntype = system_.topology().getAtomTypes().size();

--- a/src/gromacs/nblib/forcecalculator.h
+++ b/src/gromacs/nblib/forcecalculator.h
@@ -69,7 +69,7 @@ public:
 
     //! Sets up and runs the kernel calls
     //! returns the forces as a vector
-    gmx::PaddedHostVector<gmx::RVec> compute(const bool printTimings = false);
+    gmx::PaddedHostVector<gmx::RVec> compute();
 
     const matrix& box() const;
 

--- a/src/gromacs/nblib/integrator.h
+++ b/src/gromacs/nblib/integrator.h
@@ -56,6 +56,7 @@ struct nbnxn_atomdata_output_t;
 namespace nblib
 {
 
+// todo Use HostVector or ArrayRef for coordinates
 void integrateCoordinates(gmx::PaddedHostVector<gmx::RVec> forces,
                           const NBKernelOptions&           options,
                           const matrix&                    box,

--- a/src/gromacs/nblib/molecules.cpp
+++ b/src/gromacs/nblib/molecules.cpp
@@ -60,7 +60,7 @@ Molecule& Molecule::addAtom(const AtomName&    atomName,
                             const Charge&      charge,
                             AtomType const&    atomType)
 {
-    if (!atomTypes_.count(atomType.name()))
+    if (atomTypes_.count(atomType.name()) == 0)
     {
         atomTypes_[atomType.name()] = atomType;
     }
@@ -102,12 +102,12 @@ int Molecule::numAtomsInMolecule() const
     return atoms_.size();
 }
 
-void Molecule::addHarmonicBond(HarmonicType harmonicBond)
+void Molecule::addHarmonicBond(const HarmonicType& harmonicBond)
 {
     harmonicInteractions_.push_back(harmonicBond);
 }
 
-void Molecule::addExclusion(const int atomIndex, const int atomIndexToExclude)
+void Molecule::addExclusion(const int& atomIndex, const int& atomIndexToExclude)
 {
     // We do not need to add exclusion in case the atom indexes are the same
     // because self exclusion are added by addAtom
@@ -155,9 +155,13 @@ std::vector<std::tuple<int, int>> Molecule::getExclusions() const
     //! normal operator<, except ignore third element
     auto sortKey = [](const auto& tup1, const auto& tup2) {
         if (std::get<0>(tup1) < std::get<0>(tup2))
+        {
             return true;
+        }
         else
+        {
             return std::get<1>(tup1) < std::get<1>(tup2);
+        }
     };
 
     //! convert exclusions given by names to indices and append

--- a/src/gromacs/nblib/molecules.cpp
+++ b/src/gromacs/nblib/molecules.cpp
@@ -102,12 +102,12 @@ int Molecule::numAtomsInMolecule() const
     return atoms_.size();
 }
 
-void Molecule::addHarmonicBond(const HarmonicType& harmonicBond)
+void Molecule::addHarmonicBond(HarmonicType harmonicBond)
 {
-    harmonicInteractions_.push_back(harmonicBond);
+    harmonicInteractions_.push_back(std::move(harmonicBond));
 }
 
-void Molecule::addExclusion(const int& atomIndex, const int& atomIndexToExclude)
+void Molecule::addExclusion(const int atomIndex, const int atomIndexToExclude)
 {
     // We do not need to add exclusion in case the atom indexes are the same
     // because self exclusion are added by addAtom

--- a/src/gromacs/nblib/molecules.h
+++ b/src/gromacs/nblib/molecules.h
@@ -96,10 +96,10 @@ public:
     template<typename T>
     Molecule& addAtom(const T& atomName, AtomType const& atomType) = delete;
 
-    void addHarmonicBond(const HarmonicType& harmonicBond);
+    void addHarmonicBond(HarmonicType harmonicBond);
 
     // TODO: add exclusions based on the unique ID given to the atom of the molecule
-    void addExclusion(const int& atomIndex, const int& atomIndexToExclude);
+    void addExclusion(int atomIndex, int atomIndexToExclude);
 
     // Specify an exclusion with atom and residue names that have been added to molecule
     void addExclusion(std::tuple<std::string, std::string> atom,

--- a/src/gromacs/nblib/molecules.h
+++ b/src/gromacs/nblib/molecules.h
@@ -56,10 +56,9 @@
 
 #include "interactions.h"
 
-class TopologyBuilder;
-
 namespace nblib
 {
+class TopologyBuilder;
 
 using AtomName    = std::string;
 using Charge      = real;
@@ -97,10 +96,10 @@ public:
     template<typename T>
     Molecule& addAtom(const T& atomName, AtomType const& atomType) = delete;
 
-    void addHarmonicBond(HarmonicType harmonicBond);
+    void addHarmonicBond(const HarmonicType& harmonicBond);
 
     // TODO: add exclusions based on the unique ID given to the atom of the molecule
-    void addExclusion(const int atomIndex, const int atomIndexToExclude);
+    void addExclusion(const int& atomIndex, const int& atomIndexToExclude);
 
     // Specify an exclusion with atom and residue names that have been added to molecule
     void addExclusion(std::tuple<std::string, std::string> atom,

--- a/src/gromacs/nblib/simulationstate.cpp
+++ b/src/gromacs/nblib/simulationstate.cpp
@@ -65,10 +65,10 @@ namespace nblib
 
 SimulationState::SimulationState(const std::vector<gmx::RVec>& coord,
                                  Box                           box,
-                                 const Topology&               topology,
+                                 Topology                      topology,
                                  const std::vector<gmx::RVec>& vel) :
     box_(std::move(box)),
-    topology_(topology)
+    topology_(std::move(topology))
 {
     if (!checkNumericValues(coord))
     {

--- a/src/gromacs/nblib/simulationstate.cpp
+++ b/src/gromacs/nblib/simulationstate.cpp
@@ -65,10 +65,10 @@ namespace nblib
 
 SimulationState::SimulationState(const std::vector<gmx::RVec>& coord,
                                  Box                           box,
-                                 Topology&                     topo,
+                                 const Topology&               topology,
                                  const std::vector<gmx::RVec>& vel) :
-    box_(box),
-    topology_(topo)
+    box_(std::move(box)),
+    topology_(topology)
 {
     if (!checkNumericValues(coord))
     {

--- a/src/gromacs/nblib/simulationstate.h
+++ b/src/gromacs/nblib/simulationstate.h
@@ -68,7 +68,7 @@ public:
     //! Constructor
     SimulationState(const std::vector<gmx::RVec>& coord,
                     Box                           box,
-                    const Topology&               topology,
+                    Topology                      topology,
                     const std::vector<gmx::RVec>& vel = {});
 
     //! Copy Constructor

--- a/src/gromacs/nblib/simulationstate.h
+++ b/src/gromacs/nblib/simulationstate.h
@@ -68,7 +68,7 @@ public:
     //! Constructor
     SimulationState(const std::vector<gmx::RVec>& coord,
                     Box                           box,
-                    Topology&                     topo,
+                    const Topology&               topology,
                     const std::vector<gmx::RVec>& vel = {});
 
     //! Copy Constructor

--- a/src/gromacs/nblib/tests/simstate.cpp
+++ b/src/gromacs/nblib/tests/simstate.cpp
@@ -64,7 +64,7 @@ namespace test
 namespace
 {
 
-static void compareValues(const std::vector<gmx::RVec>& ref, const std::vector<gmx::RVec>& test)
+void compareValues(const std::vector<gmx::RVec>& ref, const std::vector<gmx::RVec>& test)
 {
     for (size_t i = 0; i < ref.size(); i++)
     {

--- a/src/gromacs/nblib/tests/util.cpp
+++ b/src/gromacs/nblib/tests/util.cpp
@@ -132,25 +132,6 @@ TEST(NBlibTest, generateVelocityCheckNumbers)
     EXPECT_EQ(ret, true);
 }
 
-TEST(NBlibTest, VectorOperatorAdditionWorksPOD)
-{
-    std::vector<int>                  v1   = { 1, 2 };
-    std::vector<int>                  v2   = { 3, 4 };
-    std::vector<std::tuple<int, int>> ref  = { { 1, 3 }, { 2, 4 } };
-    std::vector<std::tuple<int, int>> test = std::move(v1) + std::move(v2);
-    EXPECT_EQ(ref, test);
-}
-
-TEST(NBlibTest, VectorOperatorAdditionWorksNonPOD)
-{
-    std::vector<std::string>                          v1   = { "can", "this" };
-    std::vector<std::string>                          v2   = { "test", "work" };
-    std::vector<std::tuple<std::string, std::string>> ref  = { { "can", "test" },
-                                                              { "this", "work" } };
-    std::vector<std::tuple<std::string, std::string>> test = std::move(v1) + std::move(v2);
-    EXPECT_EQ(ref, test);
-}
-
 } // namespace
 } // namespace test
 } // namespace nblib

--- a/src/gromacs/nblib/topology.cpp
+++ b/src/gromacs/nblib/topology.cpp
@@ -60,12 +60,6 @@ namespace nblib
 namespace detail
 {
 
-// Converts tuples of atom indices to exclude to the gmx::ExclusionBlock format
-std::vector<gmx::ExclusionBlock> toGmxExclusionBlock(const std::vector<std::tuple<int, int>>& tupleList);
-
-// add offset to all indices in inBlock
-std::vector<gmx::ExclusionBlock> offsetGmxBlock(std::vector<gmx::ExclusionBlock> inBlock, int offset);
-
 std::vector<gmx::ExclusionBlock> toGmxExclusionBlock(const std::vector<std::tuple<int, int>>& tupleList)
 {
     std::vector<gmx::ExclusionBlock> ret;
@@ -95,7 +89,9 @@ std::vector<gmx::ExclusionBlock> toGmxExclusionBlock(const std::vector<std::tupl
 
         //! update the upper bound of the range for the next atom
         if (it1 != end(tupleList))
+        {
             it2 = std::upper_bound(it1, std::end(tupleList), *it1, firstLowerThan);
+        }
     }
 
     return ret;
@@ -216,7 +212,7 @@ TopologyBuilder& TopologyBuilder::addMolecule(const Molecule& molecule, const in
     molecules_.emplace_back(std::make_tuple(molecule, nMolecules));
     numAtoms_ += nMolecules * molecule.numAtomsInMolecule();
 
-    for (auto name_type_tuple : molecule.atomTypes_)
+    for (const auto& name_type_tuple : molecule.atomTypes_)
     {
         //! If we already have the atomType, we need to make
         //! sure that the type's parameters are actually the same

--- a/src/gromacs/nblib/topology.h
+++ b/src/gromacs/nblib/topology.h
@@ -60,8 +60,13 @@ namespace nblib
 
 namespace detail
 {
+
+// Converts tuples of atom indices to exclude to the gmx::ExclusionBlock format
 std::vector<gmx::ExclusionBlock> toGmxExclusionBlock(const std::vector<std::tuple<int, int>>& tupleList);
+
+// Add offset to all indices in inBlock
 std::vector<gmx::ExclusionBlock> offsetGmxBlock(std::vector<gmx::ExclusionBlock> inBlock, int offset);
+
 } // namespace detail
 
 /*! \inpublicapi

--- a/src/gromacs/nblib/util.h
+++ b/src/gromacs/nblib/util.h
@@ -61,21 +61,6 @@ inline void ignore_unused(T& x)
     static_cast<void>(x);
 }
 
-//! Allow creation of vector<tuple<T, T>> from two vector<T>
-template<typename T>
-std::vector<std::tuple<T, T>> operator+(std::vector<T>&& lhs, std::vector<T>&& rhs)
-{
-
-    std::vector<std::tuple<T, T>> ret(lhs.size());
-
-    std::transform(std::make_move_iterator(lhs.cbegin()), std::make_move_iterator(lhs.cend()),
-                   std::make_move_iterator(rhs.cbegin()), ret.begin(), [](auto&& lhs_val, auto&& rhs_val) {
-                       return std::make_tuple(std::move(lhs_val), std::move(rhs_val));
-                   });
-    return ret;
-}
-
-
 } // namespace nblib
 
 #endif // GROMACS_UTIL_H


### PR DESCRIPTION
This mostly increases const correctness. The one clang-format recommendation not followed is passing coordinates as pointer to the integrator.