### PR TITLE
Add argon forces test

### DIFF
--- a/src/gromacs/nblib/forcecalculator.cpp
+++ b/src/gromacs/nblib/forcecalculator.cpp
@@ -311,7 +311,6 @@ gmx::PaddedHostVector<gmx::RVec> ForceCalculator::compute()
                                  forceRec, &enerd, &nrnb);
 
     // Todo manage this at a higher level
-    nbnxn_atomdata_t*                nbat = nbv->nbat.get();
     gmx::PaddedHostVector<gmx::RVec> verletForces(system_.topology().numAtoms(), gmx::RVec(0, 0, 0));
 
     nbv->atomdata_add_nbat_f_to_f(gmx::AtomLocality::All, verletForces);

--- a/src/gromacs/nblib/forcecalculator.cpp
+++ b/src/gromacs/nblib/forcecalculator.cpp
@@ -312,7 +312,7 @@ gmx::PaddedHostVector<gmx::RVec> ForceCalculator::compute(const bool printTiming
 
     // Todo manage this at a higher level
     nbnxn_atomdata_t*                nbat = nbv->nbat.get();
-    gmx::PaddedHostVector<gmx::RVec> verletForces(nbat->numAtoms(), gmx::RVec(0, 0, 0));
+    gmx::PaddedHostVector<gmx::RVec> verletForces(system_.topology().numAtoms(), gmx::RVec(0, 0, 0));
 
     nbv->atomdata_add_nbat_f_to_f(gmx::AtomLocality::All, verletForces);
     return verletForces;


### PR DESCRIPTION
After testing to make sure that the non-bonded force parameters
(nbfp) are the same in nblib and mdrun, the forces were obtained
from mdrun and found to be the same as nblib. A test with the
values from mdrun is now added. This shows that the issue with
forces for the spc and methanol system is likely due to ordering
of nbfp.