### PR TITLE
Splits the NBXNM setup utils from the GMXForceCalculator

### DIFF
--- a/src/gromacs/nblib/forcecalculator.cpp
+++ b/src/gromacs/nblib/forcecalculator.cpp
@@ -51,12 +51,12 @@ namespace nblib
 
 ForceCalculator::ForceCalculator(const SimulationState& system, const NBKernelOptions& options)
 {
-    nbvSetupUtil_ = std::make_unique <NbvSetupUtil> (system, options);
+    nbvSetupUtil_ = std::make_unique<NbvSetupUtil>(system, options);
 
     gmxForceCalculator_ = nbvSetupUtil_->setupGmxForceCalculator();
 
-//    //! size: numAtoms
-//    masses_ = expandQuantity(system.topology(), &AtomType::mass);
+    //    //! size: numAtoms
+    //    masses_ = expandQuantity(system.topology(), &AtomType::mass);
 }
 
 //! Sets up and runs the kernel calls

--- a/src/gromacs/nblib/forcecalculator.cpp
+++ b/src/gromacs/nblib/forcecalculator.cpp
@@ -33,8 +33,6 @@
  * the research papers on the package. Check out http://www.gromacs.org.
  */
 /*! \internal \file
- * \brief
- * Implements nblib ForceCalculator
  *
  * \author Victor Holanda <victor.holanda@cscs.ch>
  * \author Joe Jordan <ejjordan@kth.se>
@@ -44,10 +42,9 @@
 #include "gmxpre.h"
 
 #include "forcecalculator.h"
-
-#include "integrator.h"
+#include "gmxcalculator.h"
 #include "gmxsetup.h"
-
+#include "integrator.h"
 
 namespace nblib
 {

--- a/src/gromacs/nblib/gmxcalculator.cpp
+++ b/src/gromacs/nblib/gmxcalculator.cpp
@@ -1,0 +1,142 @@
+/*
+ * This file is part of the GROMACS molecular simulation package.
+ *
+ * Copyright (c) 2019, by the GROMACS development team, led by
+ * Mark Abraham, David van der Spoel, Berk Hess, and Erik Lindahl,
+ * and including many others, as listed in the AUTHORS file in the
+ * top-level source directory and at http://www.gromacs.org.
+ *
+ * GROMACS is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * GROMACS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with GROMACS; if not, see
+ * http://www.gnu.org/licenses, or write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
+ *
+ * If you want to redistribute modifications to GROMACS, please
+ * consider that scientific software is very special. Version
+ * control is crucial - bugs must be traceable. We will be happy to
+ * consider code for inclusion in the official distribution, but
+ * derived work must not be called official GROMACS. Details are found
+ * in the README & COPYING files - if they are missing, get the
+ * official version at http://www.gromacs.org.
+ *
+ * To help us fund GROMACS development, we humbly ask that you cite
+ * the research papers on the package. Check out http://www.gromacs.org.
+ */
+/*! \internal \file
+ *
+ * \author Victor Holanda <victor.holanda@cscs.ch>
+ * \author Joe Jordan <ejjordan@kth.se>
+ * \author Prashanth Kanduri <kanduri@cscs.ch>
+ * \author Sebastian Keller <keller@cscs.ch>
+ */
+
+#include "gromacs/ewald/ewald_utils.h"
+#include "gromacs/math/units.h"
+#include "gromacs/mdlib/rf_util.h"
+#include "gromacs/gmxlib/nrnb.h"
+
+#include "gmxcalculator.h"
+#include "nbkerneloptions.h"
+#include "simulationstate.h"
+
+namespace nblib
+{
+
+static real ewaldCoeff(const real ewald_rtol, const real pairlistCutoff)
+{
+    return calc_ewaldcoeff_q(pairlistCutoff, ewald_rtol);
+}
+
+//! Return an interaction constants struct with members used in the benchmark set appropriately
+static interaction_const_t setupInteractionConst(const std::shared_ptr<NBKernelOptions> options)
+{
+    interaction_const_t ic;
+
+    ic.vdwtype      = evdwCUT;
+    ic.vdw_modifier = eintmodPOTSHIFT;
+    ic.rvdw         = options->pairlistCutoff;
+
+    switch (options->coulombType)
+    {
+        case BenchMarkCoulomb::Pme: ic.eeltype = eelPME; break;
+        case BenchMarkCoulomb::Cutoff: ic.eeltype = eelCUT; break;
+        case BenchMarkCoulomb::ReactionField: ic.eeltype = eelRF; break;
+        case BenchMarkCoulomb::Count:
+            GMX_THROW(gmx::InvalidInputError("Unsupported electrostatic interaction"));
+    }
+    ic.coulomb_modifier = eintmodPOTSHIFT;
+    ic.rcoulomb         = options->pairlistCutoff;
+    //! Note: values correspond to ic.coulomb_modifier = eintmodPOTSHIFT
+    ic.dispersion_shift.cpot = -1.0 / gmx::power6(ic.rvdw);
+    ic.repulsion_shift.cpot  = -1.0 / gmx::power12(ic.rvdw);
+
+    // These are the initialized values but we leave them here so that later
+    // these can become options.
+    ic.epsilon_r  = 1.0;
+    ic.epsilon_rf = 1.0;
+
+    /* Set the Coulomb energy conversion factor */
+    if (ic.epsilon_r != 0)
+    {
+        ic.epsfac = ONE_4PI_EPS0 / ic.epsilon_r;
+    }
+    else
+    {
+        /* eps = 0 is infinite dieletric: no Coulomb interactions */
+        ic.epsfac = 0;
+    }
+
+    calc_rffac(nullptr, ic.epsilon_r, ic.epsilon_rf, ic.rcoulomb, &ic.k_rf, &ic.c_rf);
+
+    if (EEL_PME_EWALD(ic.eeltype))
+    {
+        // Ewald coefficients, we ignore the potential shift
+        ic.ewaldcoeff_q = ewaldCoeff(1e-5, options->pairlistCutoff);
+        GMX_RELEASE_ASSERT(ic.ewaldcoeff_q > 0, "Ewald coefficient should be > 0");
+        ic.coulombEwaldTables = std::make_unique<EwaldCorrectionTables>();
+        init_interaction_const_tables(nullptr, &ic);
+    }
+
+    return ic;
+}
+
+GmxForceCalculator::GmxForceCalculator(const std::shared_ptr<SimulationState> system, const std::shared_ptr<NBKernelOptions> options) : enerd_(1, 0), verletForces_({})
+{
+    interactionConst_ = setupInteractionConst(options);
+
+    gmx::fillLegacyMatrix(system->box().matrix(), box_);
+
+    stepWork_.computeForces = true;
+    stepWork_.computeNonbondedForces = true;
+
+    if (options->computeVirialAndEnergy)
+    {
+        stepWork_.computeVirial = true;
+        stepWork_.computeEnergy = true;
+    }
+
+    forcerec_.ntype = system->topology().numAtoms();
+}
+
+gmx::PaddedHostVector<gmx::RVec> GmxForceCalculator::compute() {
+    t_nrnb              nrnb = { 0 };
+
+    nbv_->dispatchNonbondedKernel(gmx::InteractionLocality::Local, interactionConst_, stepWork_, enbvClearFNo,
+                                  forcerec_, &enerd_, &nrnb);
+
+    nbv_->atomdata_add_nbat_f_to_f(gmx::AtomLocality::All, verletForces_);
+
+    return verletForces_;
+}
+
+} // namespace nblib

--- a/src/gromacs/nblib/gmxcalculator.cpp
+++ b/src/gromacs/nblib/gmxcalculator.cpp
@@ -110,13 +110,15 @@ static interaction_const_t setupInteractionConst(const std::shared_ptr<NBKernelO
     return ic;
 }
 
-GmxForceCalculator::GmxForceCalculator(const std::shared_ptr<SimulationState> system, const std::shared_ptr<NBKernelOptions> options) : enerd_(1, 0), verletForces_({})
+GmxForceCalculator::GmxForceCalculator(const std::shared_ptr<SimulationState> system,
+                                       const std::shared_ptr<NBKernelOptions> options) :
+    enerd_(1, 0), verletForces_({})
 {
     interactionConst_ = setupInteractionConst(options);
 
     gmx::fillLegacyMatrix(system->box().matrix(), box_);
 
-    stepWork_.computeForces = true;
+    stepWork_.computeForces          = true;
     stepWork_.computeNonbondedForces = true;
 
     if (options->computeVirialAndEnergy)
@@ -128,11 +130,12 @@ GmxForceCalculator::GmxForceCalculator(const std::shared_ptr<SimulationState> sy
     forcerec_.ntype = system->topology().numAtoms();
 }
 
-gmx::PaddedHostVector<gmx::RVec> GmxForceCalculator::compute() {
-    t_nrnb              nrnb = { 0 };
+gmx::PaddedHostVector<gmx::RVec> GmxForceCalculator::compute()
+{
+    t_nrnb nrnb = { 0 };
 
-    nbv_->dispatchNonbondedKernel(gmx::InteractionLocality::Local, interactionConst_, stepWork_, enbvClearFNo,
-                                  forcerec_, &enerd_, &nrnb);
+    nbv_->dispatchNonbondedKernel(gmx::InteractionLocality::Local, interactionConst_, stepWork_,
+                                  enbvClearFNo, forcerec_, &enerd_, &nrnb);
 
     nbv_->atomdata_add_nbat_f_to_f(gmx::AtomLocality::All, verletForces_);
 

--- a/src/gromacs/nblib/gmxcalculator.h
+++ b/src/gromacs/nblib/gmxcalculator.h
@@ -69,7 +69,7 @@ struct GmxForceCalculator
     gmx_enerdata_t enerd_;
 
     //! Non-Bonded Verlet object for force calculation
-    std::unique_ptr <nonbonded_verlet_t> nbv_;
+    std::unique_ptr<nonbonded_verlet_t> nbv_;
 
     //! The massive class from which nbfp, shift_vec and ntypes would be used
     t_forcerec forcerec_;
@@ -77,7 +77,8 @@ struct GmxForceCalculator
     //! Tasks to perform in an MD Step
     gmx::StepWorkload stepWork_;
 
-    explicit GmxForceCalculator(const std::shared_ptr<SimulationState> system, const std::shared_ptr<NBKernelOptions> options);
+    explicit GmxForceCalculator(const std::shared_ptr<SimulationState> system,
+                                const std::shared_ptr<NBKernelOptions> options);
 
     //! Contains array for computed forces
     gmx::PaddedHostVector<gmx::RVec> verletForces_;
@@ -91,4 +92,4 @@ struct GmxForceCalculator
 
 } // namespace nblib
 
-#endif //GROMACS_GMXCALCULATOR_H
+#endif // GROMACS_GMXCALCULATOR_H

--- a/src/gromacs/nblib/gmxsetup.cpp
+++ b/src/gromacs/nblib/gmxsetup.cpp
@@ -99,18 +99,18 @@ static Nbnxm::KernelType translateBenchmarkEnum(const BenchMarkKernels& kernel)
 static gmx::compat::optional<std::string> checkKernelSetup(const NBKernelOptions& options)
 {
     GMX_RELEASE_ASSERT(options.nbnxmSimd < BenchMarkKernels::Count
-                       && options.nbnxmSimd != BenchMarkKernels::SimdAuto,
+                               && options.nbnxmSimd != BenchMarkKernels::SimdAuto,
                        "Need a valid kernel SIMD type");
 
     // Check SIMD support
     if ((options.nbnxmSimd != BenchMarkKernels::SimdNo && !GMX_SIMD)
-        #ifndef GMX_NBNXN_SIMD_4XN
+#ifndef GMX_NBNXN_SIMD_4XN
         || options.nbnxmSimd == BenchMarkKernels::Simd4XM
-        #endif
-        #ifndef GMX_NBNXN_SIMD_2XNN
+#endif
+#ifndef GMX_NBNXN_SIMD_2XNN
         || options.nbnxmSimd == BenchMarkKernels::Simd2XMM
 #endif
-            )
+    )
     {
         return "the requested SIMD kernel was not set up at configuration time";
     }
@@ -138,16 +138,16 @@ static Nbnxm::KernelSetup getKernelSetup(const NBKernelOptions& options)
     else
     {
         kernelSetup.ewaldExclusionType = options.useTabulatedEwaldCorr
-                                         ? Nbnxm::EwaldExclusionType::Table
-                                         : Nbnxm::EwaldExclusionType::Analytical;
+                                                 ? Nbnxm::EwaldExclusionType::Table
+                                                 : Nbnxm::EwaldExclusionType::Analytical;
     }
 
     return kernelSetup;
 }
 
-NbvSetupUtil::NbvSetupUtil(SimulationState  system, const NBKernelOptions& options)
+NbvSetupUtil::NbvSetupUtil(SimulationState system, const NBKernelOptions& options)
 {
-    system_ = std::make_shared<SimulationState>(system);
+    system_  = std::make_shared<SimulationState>(system);
     options_ = std::make_shared<NBKernelOptions>(options);
 
     //! Todo: find a more general way to initialize hardware
@@ -171,7 +171,7 @@ void NbvSetupUtil::unpackTopologyToGmx()
     //! size: 2*(numAtomTypes^2)
     nonbondedParameters_.reserve(2 * atomTypes.size() * atomTypes.size());
 
-    constexpr real c6factor = 6.0;
+    constexpr real c6factor  = 6.0;
     constexpr real c12factor = 12.0;
 
     for (const AtomType& atomType1 : atomTypes)
@@ -247,7 +247,8 @@ std::unique_ptr<nonbonded_verlet_t> NbvSetupUtil::setupNbnxmInstance()
                       system_->coordinates(), 0, nullptr);
 
     t_nrnb nrnb;
-    nbv->constructPairlist(gmx::InteractionLocality::Local, system_->topology().getGmxExclusions(), 0, &nrnb);
+    nbv->constructPairlist(gmx::InteractionLocality::Local, system_->topology().getGmxExclusions(),
+                           0, &nrnb);
 
     t_mdatoms mdatoms;
     // We only use (read) the atom type and charge from mdatoms
@@ -271,15 +272,16 @@ std::unique_ptr<GmxForceCalculator> NbvSetupUtil::setupGmxForceCalculator()
     matrix box_;
     gmx::fillLegacyMatrix(system_->box().matrix(), box_);
 
-    gmxForceCalculator_p->forcerec_.nbfp  = nonbondedParameters_;
+    gmxForceCalculator_p->forcerec_.nbfp = nonbondedParameters_;
     snew(gmxForceCalculator_p->forcerec_.shift_vec, SHIFTS);
     calc_shifts(box_, gmxForceCalculator_p->forcerec_.shift_vec);
 
     put_atoms_in_box(PbcType::Xyz, box_, system_->coordinates());
 
-    gmxForceCalculator_p->verletForces_ = gmx::PaddedHostVector<gmx::RVec>(system_->topology().numAtoms(), gmx::RVec(0, 0, 0));
+    gmxForceCalculator_p->verletForces_ =
+            gmx::PaddedHostVector<gmx::RVec>(system_->topology().numAtoms(), gmx::RVec(0, 0, 0));
 
     return gmxForceCalculator_p;
 }
 
-} //namespace nblib
+} // namespace nblib

--- a/src/gromacs/nblib/gmxsetup.h
+++ b/src/gromacs/nblib/gmxsetup.h
@@ -69,7 +69,7 @@ enum class CombinationRule : int
 
 struct NbvSetupUtil
 {
-    NbvSetupUtil(SimulationState  system, const NBKernelOptions& options);
+    NbvSetupUtil(SimulationState system, const NBKernelOptions& options);
 
     void unpackTopologyToGmx();
 
@@ -85,8 +85,7 @@ struct NbvSetupUtil
 
     //! Atom info where all atoms are marked to have Van der Waals interactions
     std::vector<int> atomInfoAllVdw_;
-
 };
 
-}      // namespace nblib
-#endif //GROMACS_GMXSETUP_H
+} // namespace nblib
+#endif // GROMACS_GMXSETUP_H


### PR DESCRIPTION
Puts `NbvSetupUtil` and `GMXForceCalculator` in separate files so that further development is not bottlenecked with conflicts. 