### PR TITLE
Couple of fixes to the main GROMACS repository

### DIFF
--- a/src/gromacs/gmxpreprocess/toppush.cpp
+++ b/src/gromacs/gmxpreprocess/toppush.cpp
@@ -2544,9 +2544,9 @@ void push_excl(char* line, gmx::ArrayRef<gmx::ExclusionBlock> b2, warninp* wi)
             if ((1 <= j) && (j <= b2.ssize()))
             {
                 j--;
-                b2[i].particleNumber.push_back(j);
+                b2[i].atomNumber.push_back(j);
                 /* also add the reverse exclusion! */
-                b2[j].particleNumber.push_back(i);
+                b2[j].atomNumber.push_back(i);
                 strcat(base, "%*d");
             }
             else

--- a/src/gromacs/math/matrix.h
+++ b/src/gromacs/math/matrix.h
@@ -82,7 +82,7 @@ constexpr real trace(Matrix3x3ConstSpan matrixView)
 }
 
 //! Calculate the transpose of a 3x3 matrix, from its view
-static Matrix3x3 transpose(Matrix3x3ConstSpan matrixView)
+static inline Matrix3x3 transpose(Matrix3x3ConstSpan matrixView)
 {
 
     return Matrix3x3({ matrixView(0, 0), matrixView(1, 0), matrixView(2, 0), matrixView(0, 1),

--- a/src/gromacs/nblib/gmxcalculator.cpp
+++ b/src/gromacs/nblib/gmxcalculator.cpp
@@ -123,7 +123,8 @@ void GmxForceCalculator::setupStepWorkload(const std::shared_ptr<NBKernelOptions
 
 GmxForceCalculator::GmxForceCalculator(SimulationState                        system,
                                        const std::shared_ptr<NBKernelOptions> options) :
-    verletForces_({}), enerd_(1, 0)
+    verletForces_({}),
+    enerd_(1, 0)
 {
     setupInteractionConst(options);
 

--- a/src/gromacs/nblib/simulationstate.cpp
+++ b/src/gromacs/nblib/simulationstate.cpp
@@ -67,7 +67,8 @@ SimulationState::Impl::Impl(const std::vector<gmx::RVec>& coordinates,
                             Box                           box,
                             Topology                      topology,
                             const std::vector<gmx::RVec>& velocities) :
-    box_(std::move(box)), topology_(std::move(topology))
+    box_(std::move(box)),
+    topology_(std::move(topology))
 {
     if (!checkNumericValues(coordinates))
     {

--- a/src/gromacs/nblib/tests/topology.cpp
+++ b/src/gromacs/nblib/tests/topology.cpp
@@ -221,9 +221,9 @@ TEST(NBlibTest, toGmxExclusionBlockWorks)
     std::vector<gmx::ExclusionBlock> reference;
 
     gmx::ExclusionBlock localBlock;
-    localBlock.particleNumber.push_back(0);
-    localBlock.particleNumber.push_back(1);
-    localBlock.particleNumber.push_back(2);
+    localBlock.atomNumber.push_back(0);
+    localBlock.atomNumber.push_back(1);
+    localBlock.atomNumber.push_back(2);
 
     reference.push_back(localBlock);
     reference.push_back(localBlock);
@@ -234,10 +234,10 @@ TEST(NBlibTest, toGmxExclusionBlockWorks)
     ASSERT_EQ(reference.size(), probe.size());
     for (size_t i = 0; i < reference.size(); ++i)
     {
-        ASSERT_EQ(reference[i].particleNumber.size(), probe[i].particleNumber.size());
-        for (size_t j = 0; j < reference[i].particleNumber.size(); ++j)
+        ASSERT_EQ(reference[i].atomNumber.size(), probe[i].atomNumber.size());
+        for (size_t j = 0; j < reference[i].atomNumber.size(); ++j)
         {
-            EXPECT_EQ(reference[i].particleNumber[j], probe[i].particleNumber[j]);
+            EXPECT_EQ(reference[i].atomNumber[j], probe[i].atomNumber[j]);
         }
     }
 }

--- a/src/gromacs/nblib/topology.cpp
+++ b/src/gromacs/nblib/topology.cpp
@@ -83,7 +83,7 @@ std::vector<gmx::ExclusionBlock> toGmxExclusionBlock(const std::vector<std::tupl
         //! loop over all exclusions for current particle
         for (; it1 != it2; ++it1)
         {
-            localBlock.particleNumber.push_back(std::get<1>(*it1));
+            localBlock.atomNumber.push_back(std::get<1>(*it1));
         }
 
         ret.push_back(localBlock);
@@ -103,8 +103,8 @@ std::vector<gmx::ExclusionBlock> offsetGmxBlock(std::vector<gmx::ExclusionBlock>
     //! shift particle numbers by offset
     for (auto& localBlock : inBlock)
     {
-        std::transform(std::begin(localBlock.particleNumber), std::end(localBlock.particleNumber),
-                       std::begin(localBlock.particleNumber), [offset](auto i) { return i + offset; });
+        std::transform(std::begin(localBlock.atomNumber), std::end(localBlock.atomNumber),
+                       std::begin(localBlock.atomNumber), [offset](auto i) { return i + offset; });
     }
 
     return inBlock;
@@ -146,7 +146,7 @@ gmx::ListOfLists<int> TopologyBuilder::createExclusionsListOfLists() const
     gmx::ListOfLists<int> exclusionsListOfListsGlobal;
     for (const auto& block : exclusionBlockGlobal)
     {
-        exclusionsListOfListsGlobal.pushBack(block.particleNumber);
+        exclusionsListOfListsGlobal.pushBack(block.atomNumber);
     }
 
     return exclusionsListOfListsGlobal;

--- a/src/gromacs/topology/exclusionblocks.cpp
+++ b/src/gromacs/topology/exclusionblocks.cpp
@@ -60,7 +60,7 @@ void listOfListsToExclusionBlocks(const ListOfLists<int>& b, gmx::ArrayRef<Exclu
     {
         for (int jAtom : b[i])
         {
-            b2[i].particleNumber.push_back(jAtom);
+            b2[i].atomNumber.push_back(jAtom);
         }
     }
 }
@@ -72,7 +72,7 @@ void exclusionBlocksToListOfLists(gmx::ArrayRef<const ExclusionBlock> b2, ListOf
 
     for (const auto& block : b2)
     {
-        b->pushBack(block.particleNumber);
+        b->pushBack(block.atomNumber);
     }
 }
 
@@ -84,7 +84,7 @@ void blockaToExclusionBlocks(const t_blocka* b, gmx::ArrayRef<ExclusionBlock> b2
     {
         for (int j = b->index[i]; (j < b->index[i + 1]); j++)
         {
-            b2[i].particleNumber.push_back(b->a[j]);
+            b2[i].atomNumber.push_back(b->a[j]);
         }
     }
 }
@@ -97,7 +97,7 @@ void exclusionBlocksToBlocka(gmx::ArrayRef<const ExclusionBlock> b2, t_blocka* b
     {
         b->index[i] = nra;
         int j       = 0;
-        for (const auto& entry : block.particleNumber)
+        for (const auto& entry : block.atomNumber)
         {
             b->a[nra + j] = entry;
             j++;
@@ -121,15 +121,15 @@ int countAndSortExclusions(gmx::ArrayRef<ExclusionBlock> b2)
         if (block.nra() > 0)
         {
             /* remove double entries */
-            std::sort(block.particleNumber.begin(), block.particleNumber.end());
-            for (auto atom = block.particleNumber.begin() + 1; atom != block.particleNumber.end();)
+            std::sort(block.atomNumber.begin(), block.atomNumber.end());
+            for (auto atom = block.atomNumber.begin() + 1; atom != block.atomNumber.end();)
             {
-                GMX_RELEASE_ASSERT(atom < block.particleNumber.end(),
+                GMX_RELEASE_ASSERT(atom < block.atomNumber.end(),
                                    "Need to stay in range of the size of the blocks");
                 auto prev = atom - 1;
                 if (*prev == *atom)
                 {
-                    atom = block.particleNumber.erase(atom);
+                    atom = block.atomNumber.erase(atom);
                 }
                 else
                 {

--- a/src/gromacs/topology/exclusionblocks.h
+++ b/src/gromacs/topology/exclusionblocks.h
@@ -53,9 +53,9 @@ class ListOfLists;
 struct ExclusionBlock
 {
     //! Particle numbers for exclusion.
-    std::vector<int> particleNumber;
+    std::vector<int> atomNumber;
     //! Number of particles in the exclusion.
-    int nra() const { return particleNumber.size(); }
+    int nra() const { return atomNumber.size(); }
 };
 
 /*! \brief Merge the contents of \c b2 into \c excl.


### PR DESCRIPTION
1. Roll back accidental atom->particle rename in exclusion blocks of GROMACS.
2. Make the transpose(...) function inline to remove the compilation time warning.