### PR TITLE
implemented association of names with sequence ids

### DIFF
--- a/src/gromacs/nblib/molecules.cpp
+++ b/src/gromacs/nblib/molecules.cpp
@@ -57,6 +57,11 @@ namespace nblib
 
 Molecule::Molecule(std::string moleculeName) : name_(std::move(moleculeName)) {}
 
+std::string Molecule::name() const
+{
+    return name_;
+}
+
 Molecule& Molecule::addParticle(const ParticleName& particleName,
                                 const ResidueName&  residueName,
                                 const Charge&       charge,
@@ -81,7 +86,7 @@ Molecule& Molecule::addParticle(const ParticleName& particleName,
 
     //! Add self exclusion. We just added the particle, so we know its index and that the exclusion doesn't exist yet
     std::size_t id = particles_.size() - 1;
-    exclusions_.emplace_back(std::make_tuple(id, id));
+    exclusions_.emplace_back(id, id);
 
     return *this;
 }
@@ -151,6 +156,16 @@ const Molecule::InteractionTuple& Molecule::interactionData() const
 const ParticleType& Molecule::at(const std::string& particleTypeName) const
 {
     return particleTypes_.at(particleTypeName);
+}
+
+const ParticleName& Molecule::particleName(int i) const
+{
+    return particles_[i].particleName_;
+}
+
+const ResidueName& Molecule::residueName(int i) const
+{
+    return particles_[i].residueName_;
 }
 
 std::vector<std::tuple<int, int>> Molecule::getExclusions() const

--- a/src/gromacs/nblib/molecules.h
+++ b/src/gromacs/nblib/molecules.h
@@ -132,21 +132,13 @@ public:
                         const ResidueName&  residueNameI,
                         const ParticleName& particleNameJ,
                         const ResidueName&  residueNameJ,
-                        Interaction         interaction)
-    {
-        auto& interactionContainer = pickType<Interaction>(interactionData_);
-        interactionContainer.interactions_.emplace_back(particleNameI, residueNameI, particleNameJ,
-                                                        residueNameJ, interaction.name());
-        interactionContainer.interactionTypes_.insert(
-                std::make_pair(interaction.name(), std::move(interaction)));
-    }
+                        Interaction         interaction);
 
     // add interactions with default residue name
     template<class Interaction>
-    void addInteraction(const ParticleName& particleNameI, const ParticleName& particleNameJ, Interaction interaction)
-    {
-        addInteraction(particleNameI, name_, particleNameJ, name_, interaction);
-    }
+    void addInteraction(const ParticleName& particleNameI,
+                        const ParticleName& particleNameJ,
+                        Interaction         interaction);
 
     // The number of molecules
     int numParticlesInMolecule() const;
@@ -199,6 +191,11 @@ private:
 
     //! collection of data for all types of interactions
     InteractionTuple interactionData_;
+
+    // force code generation for all BondTypes listed in the Interaction tuple
+    // compared to explict template declaration + definition, we don't have to repeat the list of
+    // templates this never gets called
+    void instantiateInteractions();
 };
 
 } // namespace nblib

--- a/src/gromacs/nblib/molecules.h
+++ b/src/gromacs/nblib/molecules.h
@@ -83,10 +83,7 @@ class Molecule
 public:
     Molecule(std::string moleculeName);
 
-    //! The molecule name
-    std::string name() const;
-
-    //! Add a particle to the molecule with full specification of parameters.
+    // Add a particle to the molecule with full specification of parameters.
     Molecule& addParticle(const ParticleName& particleName,
                           const ResidueName&  residueName,
                           const Charge&       charge,
@@ -99,19 +96,19 @@ public:
                           const V&            charge,
                           ParticleType const& particleType) = delete;
 
-    //! Add a particle to the molecule with implicit charge of 0
+    // Add a particle to the molecule with implicit charge of 0
     Molecule& addParticle(const ParticleName& particleName,
                           const ResidueName&  residueName,
                           ParticleType const& particleType);
 
-    //! Add a particle to the molecule with residueName set using particleName
+    // Add a particle to the molecule with residueName set using particleName
     Molecule& addParticle(const ParticleName& particleName, const Charge& charge, ParticleType const& particleType);
 
     // Force explicit use of correct types, covers both implicit charge and residueName
     template<typename T, typename U>
     Molecule& addParticle(const T& particleName, const U& charge, ParticleType const& particleType) = delete;
 
-    //! Add a particle to the molecule with residueName set using particleName with implicit charge of 0
+    // Add a particle to the molecule with residueName set using particleName with implicit charge of 0
     Molecule& addParticle(const ParticleName& particleName, ParticleType const& particleType);
 
     // Force explicit use of correct types
@@ -121,11 +118,11 @@ public:
     // TODO: add exclusions based on the unique ID given to the particle of the molecule
     void addExclusion(int particleIndex, int particleIndexToExclude);
 
-    //! Specify an exclusion with particle and residue names that have been added to molecule
+    // Specify an exclusion with particle and residue names that have been added to molecule
     void addExclusion(std::tuple<std::string, std::string> particle,
                       std::tuple<std::string, std::string> particleToExclude);
 
-    //! Specify an exclusion with particle names that have been added to molecule
+    // Specify an exclusion with particle names that have been added to molecule
     void addExclusion(const std::string& particleName, const std::string& particleNameToExclude);
 
     //! add various types of interactions to the molecule
@@ -144,31 +141,34 @@ public:
                 std::make_pair(interaction.name(), std::move(interaction)));
     }
 
-    //! add interactions with default residue name
+    // add interactions with default residue name
     template<class Interaction>
     void addInteraction(const ParticleName& particleNameI, const ParticleName& particleNameJ, Interaction interaction)
     {
         addInteraction(particleNameI, name_, particleNameJ, name_, interaction);
     }
 
-    //! The number of molecules
+    // The number of molecules
     int numParticlesInMolecule() const;
 
-    //! Return the ParticleType data for a specific particle name that has been added to the molecule
+    // Return the ParticleType data for a specific particle name that has been added to the molecule
     const ParticleType& at(const std::string& particlesTypeName) const;
 
-    //! convert exclusions given by name to indices and unify with exclusions given by indices
-    //! returns a sorted vector containing no duplicates of particles to exclude by indices
+    // convert exclusions given by name to indices and unify with exclusions given by indices
+    // returns a sorted vector containing no duplicates of particles to exclude by indices
     std::vector<std::tuple<int, int>> getExclusions() const;
 
-    //! return all interactions stored in Molecule
+    // return all interactions stored in Molecule
     const InteractionTuple& interactionData() const;
 
-    //! return name of ith particle
+    // return name of ith particle
     const ParticleName& particleName(int i) const;
 
-    //! return name of ith residue
+    // return name of ith residue
     const ResidueName& residueName(int i) const;
+
+    // The molecule name
+    std::string name() const;
 
     friend class TopologyBuilder;
 

--- a/src/gromacs/nblib/molecules.h
+++ b/src/gromacs/nblib/molecules.h
@@ -73,8 +73,8 @@ class Molecule
     {
         using type = Bond;
 
-        std::unordered_map<Name, Bond>                            interactionTypes_;
-        std::vector<std::tuple<ParticleName, ParticleName, Name>> interactions_;
+        std::unordered_map<Name, Bond> interactionTypes_;
+        std::vector<std::tuple<ParticleName, ResidueName, ParticleName, ResidueName, Name>> interactions_;
     };
 
     using InteractionTuple =
@@ -83,7 +83,10 @@ class Molecule
 public:
     Molecule(std::string moleculeName);
 
-    // Add a particle to the molecule with full specification of parameters.
+    //! The molecule name
+    std::string name() const;
+
+    //! Add a particle to the molecule with full specification of parameters.
     Molecule& addParticle(const ParticleName& particleName,
                           const ResidueName&  residueName,
                           const Charge&       charge,
@@ -96,19 +99,19 @@ public:
                           const V&            charge,
                           ParticleType const& particleType) = delete;
 
-    // Add a particle to the molecule with implicit charge of 0
+    //! Add a particle to the molecule with implicit charge of 0
     Molecule& addParticle(const ParticleName& particleName,
                           const ResidueName&  residueName,
                           ParticleType const& particleType);
 
-    // Add a particle to the molecule with residueName set using particleName
+    //! Add a particle to the molecule with residueName set using particleName
     Molecule& addParticle(const ParticleName& particleName, const Charge& charge, ParticleType const& particleType);
 
     // Force explicit use of correct types, covers both implicit charge and residueName
     template<typename T, typename U>
     Molecule& addParticle(const T& particleName, const U& charge, ParticleType const& particleType) = delete;
 
-    // Add a particle to the molecule with residueName set using particleName with implicit charge of 0
+    //! Add a particle to the molecule with residueName set using particleName with implicit charge of 0
     Molecule& addParticle(const ParticleName& particleName, ParticleType const& particleType);
 
     // Force explicit use of correct types
@@ -118,38 +121,54 @@ public:
     // TODO: add exclusions based on the unique ID given to the particle of the molecule
     void addExclusion(int particleIndex, int particleIndexToExclude);
 
-    // Specify an exclusion with particle and residue names that have been added to molecule
+    //! Specify an exclusion with particle and residue names that have been added to molecule
     void addExclusion(std::tuple<std::string, std::string> particle,
                       std::tuple<std::string, std::string> particleToExclude);
 
-    // Specify an exclusion with particle names that have been added to molecule
+    //! Specify an exclusion with particle names that have been added to molecule
     void addExclusion(const std::string& particleName, const std::string& particleNameToExclude);
 
     //! add various types of interactions to the molecule
     //! Note: adding an interaction type not listed in InteractionTuple in this class results in a compilation error
     template<class Interaction>
-    void addInteraction(ParticleName particleNameI, ParticleName particleNameJ, Interaction interaction)
+    void addInteraction(const ParticleName& particleNameI,
+                        const ResidueName&  residueNameI,
+                        const ParticleName& particleNameJ,
+                        const ResidueName&  residueNameJ,
+                        Interaction         interaction)
     {
         auto& interactionContainer = pickType<Interaction>(interactionData_);
-        interactionContainer.interactions_.emplace_back(particleNameI, particleNameJ, interaction.name());
-        if (interactionContainer.interactionTypes_.count(interaction.name()) == 0)
-        {
-            interactionContainer.interactionTypes_[interaction.name()] = std::move(interaction);
-        }
+        interactionContainer.interactions_.emplace_back(particleNameI, residueNameI, particleNameJ,
+                                                        residueNameJ, interaction.name());
+        interactionContainer.interactionTypes_.insert(
+                std::make_pair(interaction.name(), std::move(interaction)));
     }
 
-    // The number of molecules
+    //! add interactions with default residue name
+    template<class Interaction>
+    void addInteraction(const ParticleName& particleNameI, const ParticleName& particleNameJ, Interaction interaction)
+    {
+        addInteraction(particleNameI, name_, particleNameJ, name_, interaction);
+    }
+
+    //! The number of molecules
     int numParticlesInMolecule() const;
 
-    // Return the ParticleType data for a specific particle name that has been added to the molecule
+    //! Return the ParticleType data for a specific particle name that has been added to the molecule
     const ParticleType& at(const std::string& particlesTypeName) const;
 
-    // convert exclusions given by name to indices and unify with exclusions given by indices
-    // returns a sorted vector containing no duplicates of particles to exclude by indices
+    //! convert exclusions given by name to indices and unify with exclusions given by indices
+    //! returns a sorted vector containing no duplicates of particles to exclude by indices
     std::vector<std::tuple<int, int>> getExclusions() const;
 
     //! return all interactions stored in Molecule
     const InteractionTuple& interactionData() const;
+
+    //! return name of ith particle
+    const ParticleName& particleName(int i) const;
+
+    //! return name of ith residue
+    const ResidueName& residueName(int i) const;
 
     friend class TopologyBuilder;
 

--- a/src/gromacs/nblib/tests/testsystems.cpp
+++ b/src/gromacs/nblib/tests/testsystems.cpp
@@ -108,6 +108,10 @@ WaterMoleculeBuilder::WaterMoleculeBuilder() : water_("SOL")
     water_.addParticle(ParticleName("Oxygen"), Charges.at("Ow"), plib.type("Ow"));
     water_.addParticle(ParticleName("H1"), Charges.at("Hw"), plib.type("H"));
     water_.addParticle(ParticleName("H2"), Charges.at("Hw"), plib.type("H"));
+
+    HarmonicBondType ohBond("oh", 1., 1.);
+    water_.addInteraction("Oxygen", "H1", ohBond);
+    water_.addInteraction("Oxygen", "H2", ohBond);
 }
 
 Molecule WaterMoleculeBuilder::waterMolecule()

--- a/src/gromacs/nblib/tests/topology.cpp
+++ b/src/gromacs/nblib/tests/topology.cpp
@@ -180,6 +180,19 @@ TEST(NBlibTest, TopologyHasExclusions)
     compareLists(testExclusions, refExclusions);
 }
 
+TEST(NBlibTest, TopologyHasSequencing)
+{
+    WaterTopology waters;
+    Topology      watersTopology = waters.buildTopology(2);
+
+    EXPECT_EQ(0, watersTopology.sequenceID("SOL", 0, "SOL", "Oxygen"));
+    EXPECT_EQ(1, watersTopology.sequenceID("SOL", 0, "SOL", "H1"));
+    EXPECT_EQ(2, watersTopology.sequenceID("SOL", 0, "SOL", "H2"));
+    EXPECT_EQ(3, watersTopology.sequenceID("SOL", 1, "SOL", "Oxygen"));
+    EXPECT_EQ(4, watersTopology.sequenceID("SOL", 1, "SOL", "H1"));
+    EXPECT_EQ(5, watersTopology.sequenceID("SOL", 1, "SOL", "H2"));
+}
+
 TEST(NBlibTest, TopologyHasNonbondedParameters)
 {
     WaterTopology waters;
@@ -197,21 +210,6 @@ TEST(NBlibTest, TopologyHasNonbondedParameters)
     EXPECT_EQ(refC6, testC6);
     EXPECT_EQ(refC12, testC12);
 }
-
-//! Todo: this belongs to ForceCalculator
-// TEST(NBlibTest, TopologyHasParticlesInfoAllVdw)
-//{
-//    TwoWaterMolecules      waters;
-//    Topology               watersTopology = waters.buildTopology();
-//    const std::vector<int> test           = watersTopology.getParticleInfoAllVdw();
-//    std::vector<int>       ref;
-//    ref.resize(watersTopology.numParticles());
-//    for (size_t particleI = 0; particleI < ref.size(); particleI++)
-//    {
-//        SET_CGINFO_HAS_VDW(ref[particleI]);
-//    }
-//    EXPECT_EQ(ref, test);
-//}
 
 TEST(NBlibTest, toGmxExclusionBlockWorks)
 {

--- a/src/gromacs/nblib/topology.cpp
+++ b/src/gromacs/nblib/topology.cpp
@@ -110,6 +110,35 @@ std::vector<gmx::ExclusionBlock> offsetGmxBlock(std::vector<gmx::ExclusionBlock>
     return inBlock;
 }
 
+int EnumerationKey::operator()(const std::string&  moleculeName,
+                               int                 moleculeNr,
+                               const ResidueName&  residueName,
+                               const ParticleName& particleName)
+{
+    return data_[moleculeName][moleculeNr][residueName][particleName];
+}
+
+void EnumerationKey::enumerate(const std::vector<std::tuple<Molecule, int>>& moleculesList)
+{
+    int currentID = 0;
+    for (auto& molNumberTuple : moleculesList)
+    {
+        const Molecule& molecule = std::get<0>(molNumberTuple);
+        size_t          numMols  = std::get<1>(molNumberTuple);
+
+        auto& moleculeMap = data_[molecule.name()];
+
+        for (size_t i = 0; i < numMols; ++i)
+        {
+            auto& moleculeNrMap = moleculeMap[i];
+            for (int j = 0; j < molecule.numParticlesInMolecule(); ++j)
+            {
+                moleculeNrMap[molecule.residueName(j)][molecule.particleName(j)] = currentID++;
+            }
+        }
+    }
+}
+
 } // namespace detail
 
 TopologyBuilder::TopologyBuilder() : numParticles_(0) {}
@@ -188,6 +217,7 @@ Topology TopologyBuilder::buildTopology()
         return data.charge_;
     });
 
+    // map unique ParticleTypes to IDs
     std::unordered_map<std::string, int> nameToId;
     for (auto& name_particleType_tuple : particleTypes_)
     {
@@ -201,6 +231,10 @@ Topology TopologyBuilder::buildTopology()
                 return nameToId[data.particleTypeName_];
             });
 
+    detail::EnumerationKey enumerationKey;
+    enumerationKey.enumerate(molecules_);
+    topology_.enumerationKey_ = std::move(enumerationKey);
+
     return topology_;
 }
 
@@ -211,7 +245,7 @@ TopologyBuilder& TopologyBuilder::addMolecule(const Molecule& molecule, const in
      * 2. Append exclusion list into the data structure
      */
 
-    molecules_.emplace_back(std::make_tuple(molecule, nMolecules));
+    molecules_.emplace_back(molecule, nMolecules);
     numParticles_ += nMolecules * molecule.numParticlesInMolecule();
 
     for (const auto& name_type_tuple : molecule.particleTypes_)
@@ -253,6 +287,11 @@ const std::vector<ParticleType>& Topology::getParticleTypes() const
 const std::vector<int>& Topology::getParticleTypeIdOfAllParticles() const
 {
     return particleTypeIdOfAllParticles_;
+}
+
+int Topology::sequenceID(std::string moleculeName, int moleculeNr, ResidueName residueName, ParticleName particleName)
+{
+    return enumerationKey_(moleculeName, moleculeNr, residueName, particleName);
 }
 
 } // namespace nblib

--- a/src/gromacs/nblib/topology.cpp
+++ b/src/gromacs/nblib/topology.cpp
@@ -111,15 +111,15 @@ std::vector<gmx::ExclusionBlock> offsetGmxBlock(std::vector<gmx::ExclusionBlock>
     return inBlock;
 }
 
-int EnumerationKey::operator()(const std::string&  moleculeName,
-                               int                 moleculeNr,
-                               const ResidueName&  residueName,
-                               const ParticleName& particleName)
+int ParticleSequencer::operator()(const std::string&  moleculeName,
+                                  int                 moleculeNr,
+                                  const ResidueName&  residueName,
+                                  const ParticleName& particleName)
 {
     return data_[moleculeName][moleculeNr][residueName][particleName];
 }
 
-void EnumerationKey::enumerate(const std::vector<std::tuple<Molecule, int>>& moleculesList)
+void ParticleSequencer::build(const std::vector<std::tuple<Molecule, int>>& moleculesList)
 {
     int currentID = 0;
     for (auto& molNumberTuple : moleculesList)
@@ -232,9 +232,9 @@ Topology TopologyBuilder::buildTopology()
                 return nameToId[data.particleTypeName_];
             });
 
-    detail::EnumerationKey enumerationKey;
-    enumerationKey.enumerate(molecules_);
-    topology_.enumerationKey_ = std::move(enumerationKey);
+    detail::ParticleSequencer particleSequencer;
+    particleSequencer.build(molecules_);
+    topology_.particleSequencer_ = std::move(particleSequencer);
 
     topology_.combinationRule_         = particleTypesInteractions_.getCombinationRule();
     topology_.nonBondedInteractionMap_ = particleTypesInteractions_.generateTable();
@@ -317,7 +317,7 @@ const std::vector<int>& Topology::getParticleTypeIdOfAllParticles() const
 
 int Topology::sequenceID(std::string moleculeName, int moleculeNr, ResidueName residueName, ParticleName particleName)
 {
-    return enumerationKey_(moleculeName, moleculeNr, residueName, particleName);
+    return particleSequencer_(moleculeName, moleculeNr, residueName, particleName);
 }
 
 const NonBondedInteractionMap& Topology::getNonBondedInteractionMap() const

--- a/src/gromacs/nblib/topology.h
+++ b/src/gromacs/nblib/topology.h
@@ -71,7 +71,7 @@ std::vector<gmx::ExclusionBlock> toGmxExclusionBlock(const std::vector<std::tupl
 std::vector<gmx::ExclusionBlock> offsetGmxBlock(std::vector<gmx::ExclusionBlock> inBlock, int offset);
 
 //! Helper class for Topology to keep track of particle IDs
-class EnumerationKey
+class ParticleSequencer
 {
     // store by (molecule name, molecule nr, residue name, particle name)
     using DataType =
@@ -79,7 +79,7 @@ class EnumerationKey
 
 public:
     //! build sequence from a list of molecules
-    void enumerate(const std::vector<std::tuple<Molecule, int>>&);
+    void build(const std::vector<std::tuple<Molecule, int>>& moleculesList);
 
     //! access ID by (molecule name, molecule nr, residue name, particle name)
     int operator()(const std::string&, int, const ResidueName&, const ParticleName&);
@@ -141,7 +141,7 @@ private:
     //! Information about exclusions.
     gmx::ListOfLists<int> exclusions_;
     //! Associate molecule, residue and particle names with sequence numbers
-    detail::EnumerationKey enumerationKey_;
+    detail::ParticleSequencer particleSequencer_;
     //! Map that should hold all nonbonded interactions for all particle types
     NonBondedInteractionMap nonBondedInteractionMap_;
     //! Combination Rule used to generate the nonbonded interactions

--- a/src/gromacs/nblib/util.h
+++ b/src/gromacs/nblib/util.h
@@ -125,4 +125,41 @@ decltype(auto) pickType(Tuple& tup)
 
 } // namespace nblib
 
+namespace std17
+{
+
+// std::apply and std::invoke are part of C++17
+// this code can be removed once the project moves to C++17
+
+namespace detail
+{
+
+// stripped down version of std::invoke, does not handle class member functions
+template<class F, class... Args>
+constexpr decltype(auto) invoke(F&& f, Args&&... args)
+{
+    // call f with all arguments
+    return std::forward<F>(f)(std::forward<Args>(args)...);
+}
+
+template<class F, class Tuple, size_t... Is>
+constexpr decltype(auto) apply_impl(F&& f, Tuple&& t, std::index_sequence<Is...>)
+{
+    // unpack the tuple t into a function parameter pack and forward to invoke
+    return invoke(std::forward<F>(f), std::get<Is>(std::forward<Tuple>(t))...);
+}
+
+} // namespace detail
+
+template<class F, class Tuple>
+constexpr decltype(auto) apply(F&& f, Tuple&& t)
+{
+    // generate an index sequence to access all tuple elements
+    return detail::apply_impl(std::forward<F>(f), std::forward<Tuple>(t),
+                              std::make_index_sequence<std::tuple_size<std::decay_t<Tuple>>{}>{});
+}
+
+} // namespace std17
+
+
 #endif // GROMACS_UTIL_H


### PR DESCRIPTION
This implements
`int Topology::sequenceID(std::string moleculeName, int moleculeNr, ResidueName residueName, ParticleName particleName)`

which will be useful for the interaction data aggregation inside topology from multiple molecules.

Change-Id: I3d67cfff593785f6ac6af295e36b06728e313d81