### PR TITLE
Modernize cmake handling

### DIFF
--- a/src/gromacs/CMakeLists.txt
+++ b/src/gromacs/CMakeLists.txt
@@ -259,6 +259,8 @@ a clFFT package, or use the latest GROMACS 2018 point release.")
     endif()
 endif()
 
+target_sources(libgromacs PRIVATE nblib)
+
 # Permit GROMACS code to include externally developed headers, such as
 # the functionality from the nonstd project that we use for
 # gmx::compat::optional. These are included as system headers so that

--- a/src/gromacs/CMakeLists.txt
+++ b/src/gromacs/CMakeLists.txt
@@ -259,8 +259,6 @@ a clFFT package, or use the latest GROMACS 2018 point release.")
     endif()
 endif()
 
-target_sources(libgromacs PRIVATE nblib)
-
 # Permit GROMACS code to include externally developed headers, such as
 # the functionality from the nonstd project that we use for
 # gmx::compat::optional. These are included as system headers so that

--- a/src/gromacs/nblib/CMakeLists.txt
+++ b/src/gromacs/nblib/CMakeLists.txt
@@ -38,13 +38,47 @@
 # \author Sebastian Keller <keller@cscs.ch>
 #
 
-file(GLOB NBLIB_SOURCES *.cpp)
+add_library(nblib "")
 
-install(FILES
+target_sources(nblib
+        INTERFACE
+        bondtypes.h
+        box.h
+        forcecalculator.h
+        integrator.h
+        interactions.h
+        molecules.h
+        nbkerneldef.h
         nbkerneloptions.h
-        DESTINATION include/nblib)
+        particletype.h
+        simulationstate.h
+        topology.h
+        util.h
+        )
 
-set(LIBGROMACS_SOURCES ${LIBGROMACS_SOURCES} ${NBLIB_SOURCES} PARENT_SCOPE)
+target_sources(nblib
+        PRIVATE
+        bondtypes.cpp
+        box.cpp
+        forcecalculator.cpp
+        gmxcalculator.h
+        gmxcalculator.cpp
+        gmxsetup.h
+        gmxsetup.cpp
+        integrator.cpp
+        interactions.cpp
+        molecules.cpp
+        particletype.cpp
+        simulationstate.cpp
+        topology.cpp
+        util.cpp
+        )
+
+set_target_properties(nblib
+        PROPERTIES
+        LINKER_LANGUAGE CXX
+        OUTPUT_NAME "nblib"
+        )
 
 if(BUILD_TESTING)
     add_subdirectory(tests)

--- a/src/gromacs/nblib/gmxsetup.cpp
+++ b/src/gromacs/nblib/gmxsetup.cpp
@@ -44,7 +44,8 @@
 
 #include "gmxsetup.h"
 
-#include "gromacs/compat/optional.h"
+#include "external/nonstd/optional.hpp"
+
 #include "gromacs/ewald/ewald_utils.h"
 #include "gromacs/gmxlib/nrnb.h"
 #include "gromacs/mdlib/gmx_omp_nthreads.h"
@@ -77,7 +78,7 @@ static Nbnxm::KernelType translateBenchmarkEnum(const BenchMarkKernels& kernel)
  *
  * Returns an error string when the kernel is not available.
  */
-static gmx::compat::optional<std::string> checkKernelSetup(const NBKernelOptions& options)
+static nonstd::optional<std::string> checkKernelSetup(const NBKernelOptions& options)
 {
     GMX_RELEASE_ASSERT(options.nbnxmSimd < BenchMarkKernels::Count
                                && options.nbnxmSimd != BenchMarkKernels::SimdAuto,

--- a/src/gromacs/nblib/tests/CMakeLists.txt
+++ b/src/gromacs/nblib/tests/CMakeLists.txt
@@ -60,11 +60,9 @@ gmx_add_gtest_executable(
     util.cpp
     topology.cpp
     interactions.cpp
-    # pseudo-library for code for mdrun
-    #$<TARGET_OBJECTS:nblib_objlib>
     )
-target_link_libraries(${exename} PRIVATE nblib_test_infrastructure)
-gmx_register_gtest_test(${testname} ${exename} OPENMP_THREADS 1 INTEGRATION_TEST)
+target_link_libraries(${exename} PRIVATE nblib_test_infrastructure nblib)
+gmx_register_gtest_test(${testname} ${exename})
 
 
 set(testname "NbLibTests")
@@ -77,8 +75,6 @@ gmx_add_gtest_executable(
     nbkernelsystem.cpp
     nbnxnsetup.cpp
     gmxcalculator.cpp
-    # pseudo-library for code for mdrun
-    #$<TARGET_OBJECTS:nblib_objlib>
     )
-target_link_libraries(${exename} PRIVATE nblib_test_infrastructure)
-gmx_register_gtest_test(${testname} ${exename} OPENMP_THREADS 1 INTEGRATION_TEST)
+target_link_libraries(${exename} PRIVATE nblib_test_infrastructure nblib)
+gmx_register_gtest_test(${testname} ${exename})


### PR DESCRIPTION
* Updated cmake requirement to 3.13 (as in gromacs master).
* Separated nblib interface targets.
* Now include optional in more standard way.
* Remove flags from test invocation that only apply to
  wrapped binaries.