### PR TITLE
Expose nblib as library and add sample code

### DIFF
--- a/src/gromacs/CMakeLists.txt
+++ b/src/gromacs/CMakeLists.txt
@@ -217,6 +217,11 @@ gmx_target_compile_options(libgromacs)
 target_compile_definitions(libgromacs PRIVATE HAVE_CONFIG_H)
 target_include_directories(libgromacs SYSTEM BEFORE PRIVATE ${PROJECT_SOURCE_DIR}/src/external/thread_mpi/include)
 
+if(GMX_INSTALL_NBLIB_API)
+    install(FILES
+            DESTINATION include/nblib)
+endif()
+
 if (GMX_USE_OPENCL)
     option(GMX_EXTERNAL_CLFFT "True if an external clFFT is required to be used" FALSE)
     mark_as_advanced(GMX_EXTERNAL_CLFFT)

--- a/src/gromacs/math/CMakeLists.txt
+++ b/src/gromacs/math/CMakeLists.txt
@@ -41,6 +41,16 @@ install(FILES
         vectypes.h
         DESTINATION include/gromacs/math)
 
+if(GMX_INSTALL_NBLIB_API)
+    install(FILES
+            functions.h
+            matrix.h
+            multidimarray.h
+            vec.h
+            vectypes.h
+            DESTINATION include/nblib/gromacs/math)
+endif()
+
 if (BUILD_TESTING)
     add_subdirectory(tests)
 endif()

--- a/src/gromacs/mdspan/CMakeLists.txt
+++ b/src/gromacs/mdspan/CMakeLists.txt
@@ -32,6 +32,15 @@
 # To help us fund GROMACS development, we humbly ask that you cite
 # the research papers on the package. Check out http://www.gromacs.org.
 
+if(GMX_INSTALL_NBLIB_API)
+install(FILES
+        accessor_policy.h
+        extents.h
+        layouts.h
+        mdspan.h
+        DESTINATION include/nblib/gromacs/mdspan)
+endif()
+
 if (BUILD_TESTING)
     add_subdirectory(tests)
 endif()

--- a/src/gromacs/nblib/CMakeLists.txt
+++ b/src/gromacs/nblib/CMakeLists.txt
@@ -38,32 +38,14 @@
 # \author Sebastian Keller <keller@cscs.ch>
 #
 
-add_library(nblib "")
-
-target_sources(nblib
-        INTERFACE
-        bondtypes.h
-        box.h
-        forcecalculator.h
-        integrator.h
-        interactions.h
-        molecules.h
-        nbkerneldef.h
-        nbkerneloptions.h
-        particletype.h
-        simulationstate.h
-        topology.h
-        util.h
-        )
+add_library(nblib SHARED "")
 
 target_sources(nblib
         PRIVATE
         bondtypes.cpp
         box.cpp
         forcecalculator.cpp
-        gmxcalculator.h
         gmxcalculator.cpp
-        gmxsetup.h
         gmxsetup.cpp
         integrator.cpp
         interactions.cpp
@@ -79,6 +61,38 @@ set_target_properties(nblib
         LINKER_LANGUAGE CXX
         OUTPUT_NAME "nblib"
         )
+
+target_link_libraries(nblib PRIVATE libgromacs)
+
+install(TARGETS nblib
+        EXPORT nblib
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        INCLUDES DESTINATION include
+        )
+
+if(GMX_INSTALL_NBLIB_API)
+    install(FILES
+            basicdefinitions.h
+            bondtypes.h
+            box.h
+            forcecalculator.h
+            gmxcalculator.h
+            gmxsetup.h
+            integrator.h
+            interactions.h
+            molecules.h
+            nbkerneldef.h
+            nbkerneloptions.h
+            particletype.h
+            simulationstate.h
+            topology.h
+            util.h
+            DESTINATION include/nblib/gromacs/nblib)
+endif()
+
+add_subdirectory(samples)
 
 if(BUILD_TESTING)
     add_subdirectory(tests)

--- a/src/gromacs/nblib/forcecalculator.cpp
+++ b/src/gromacs/nblib/forcecalculator.cpp
@@ -51,6 +51,8 @@
 namespace nblib
 {
 
+ForceCalculator::~ForceCalculator() = default;
+
 ForceCalculator::ForceCalculator(const SimulationState& system, const NBKernelOptions& options)
 {
     gmxForceCalculator_ = nblib::GmxSetupDirector::setupGmxForceCalculator(system, options);

--- a/src/gromacs/nblib/forcecalculator.h
+++ b/src/gromacs/nblib/forcecalculator.h
@@ -64,6 +64,8 @@ public:
      */
     ForceCalculator(const SimulationState& system, const NBKernelOptions& options);
 
+    ~ForceCalculator();
+
     /*! \brief Sets up and runs the kernel calls
      *
      * \todo Refactor this function to return a handle to dispatchNonbondedKernel

--- a/src/gromacs/nblib/samples/CMakeLists.txt
+++ b/src/gromacs/nblib/samples/CMakeLists.txt
@@ -1,8 +1,7 @@
 #
 # This file is part of the GROMACS molecular simulation package.
 #
-# Copyright (c) 2010,2011,2012,2013,2014 by the GROMACS development team.
-# Copyright (c) 2015,2017,2018,2019,2020, by the GROMACS development team, led by
+# Copyright (c) 2020, by the GROMACS development team, led by
 # Mark Abraham, David van der Spoel, Berk Hess, and Erik Lindahl,
 # and including many others, as listed in the AUTHORS file in the
 # top-level source directory and at http://www.gromacs.org.
@@ -32,52 +31,28 @@
 #
 # To help us fund GROMACS development, we humbly ask that you cite
 # the research papers on the package. Check out http://www.gromacs.org.
-
-file(GLOB UTILITY_SOURCES *.cpp)
-if (GMX_GPU AND NOT GMX_USE_OPENCL)
-    gmx_add_libgromacs_sources(cuda_version_information.cu)
-endif()
-set(LIBGROMACS_SOURCES ${LIBGROMACS_SOURCES} ${UTILITY_SOURCES} PARENT_SCOPE)
-
-# TODO: (https://redmine.gromacs.org/issues/988) Find a new convention for defining public API.
-install(FILES
-        basedefinitions.h
-        current_function.h
-        gmxassert.h
-        range.h
-        real.h
-        smalloc.h
-        real.h
-        DESTINATION include/gromacs/utility)
-
-if(GMX_INSTALL_LEGACY_API)
-  install(FILES
-          arrayref.h
-          baseversion.h
-          classhelpers.h
-          enumerationhelpers.h
-          exceptions.h
-          listoflists.h
-          programcontext.h
-          range.h
-          smalloc.h
-          unique_cptr.h
-          DESTINATION include/gromacs/utility)
-endif()
+#
+# \author Victor Holanda <victor.holanda@cscs.ch>
+# \author Joe Jordan <ejjordan@kth.se>
+# \author Prashanth Kanduri <kanduri@cscs.ch>
+# \author Sebastian Keller <keller@cscs.ch>
+#
 
 if(GMX_INSTALL_NBLIB_API)
-    install(FILES
-            arrayref.h
-            basedefinitions.h
-            classhelpers.h
-            current_function.h
-            exceptions.h
-            gmxassert.h
-            listoflists.h
-            real.h
-            DESTINATION include/nblib/gromacs/utility)
+    add_executable(argon-forces-integration "")
+
+    target_sources(argon-forces-integration
+            PRIVATE
+            argon-forces-integration.cpp
+            )
+
+    target_link_libraries(argon-forces-integration PRIVATE nblib)
+    message("where ${CMAKE_INSTALL_BINDIR}")
+    install(
+            TARGETS
+            argon-forces-integration
+            DESTINATION
+            ${CMAKE_INSTALL_BINDIR}
+    )
 endif()
 
-if (BUILD_TESTING)
-    add_subdirectory(tests)
-endif()

--- a/src/gromacs/nblib/samples/argon-forces-integration.cpp
+++ b/src/gromacs/nblib/samples/argon-forces-integration.cpp
@@ -1,0 +1,95 @@
+#include <cstdio>
+
+#include "gromacs/nblib/particletype.h"
+#include "gromacs/nblib/molecules.h"
+#include "gromacs/nblib/topology.h"
+#include "gromacs/nblib/box.h"
+#include "gromacs/nblib/simulationstate.h"
+#include "gromacs/nblib/nbkerneloptions.h"
+#include "gromacs/nblib/forcecalculator.h"
+#include "gromacs/nblib/integrator.h"
+
+using namespace nblib;
+
+//! \internal \brief Parameters from gromos43A1
+struct ArAtom
+{
+    ParticleName name = "Ar";
+    Mass         mass = 39.94800;
+    C6           c6   = 0.0062647225;
+    C12          c12  = 9.847044e-06;
+};
+
+ParticleTypesInteractions interactions;
+Molecule                  argonMolecule("AR");
+TopologyBuilder           topologyBuilder;
+Box                       box(6.05449);
+int                       numParticles = 12;
+NBKernelOptions           options      = NBKernelOptions();
+
+std::vector<gmx::RVec> coordinates = {
+    { 0.794, 1.439, 0.610 }, { 1.397, 0.673, 1.916 }, { 0.659, 1.080, 0.573 },
+    { 1.105, 0.090, 3.431 }, { 1.741, 1.291, 3.432 }, { 1.936, 1.441, 5.873 },
+    { 0.960, 2.246, 1.659 }, { 0.382, 3.023, 2.793 }, { 0.053, 4.857, 4.242 },
+    { 2.655, 5.057, 2.211 }, { 4.114, 0.737, 0.614 }, { 5.977, 5.104, 5.217 },
+};
+
+std::vector<gmx::RVec> velocities = {
+    { 0.0055, -0.1400, 0.2127 },   { 0.0930, -0.0160, -0.0086 }, { 0.1678, 0.2476, -0.0660 },
+    { 0.1591, -0.0934, -0.0835 },  { -0.0317, 0.0573, 0.1453 },  { 0.0597, 0.0013, -0.0462 },
+    { 0.0484, -0.0357, 0.0168 },   { 0.0530, 0.0295, -0.2694 },  { -0.0550, -0.0896, 0.0494 },
+    { -0.0799, -0.2534, -0.0079 }, { 0.0436, -0.1557, 0.1849 },  { -0.0214, 0.0446, 0.0758 },
+};
+
+std::vector<gmx::RVec> forces = {
+    { 0.0000, 0.0000, 0.0000 }, { 0.0000, 0.0000, 0.0000 }, { 0.0000, 0.0000, 0.0000 },
+    { 0.0000, 0.0000, 0.0000 }, { 0.0000, 0.0000, 0.0000 }, { 0.0000, 0.0000, 0.0000 },
+    { 0.0000, 0.0000, 0.0000 }, { 0.0000, 0.0000, 0.0000 }, { 0.0000, 0.0000, 0.0000 },
+    { 0.0000, 0.0000, 0.0000 }, { 0.0000, 0.0000, 0.0000 }, { 0.0000, 0.0000, 0.0000 },
+};
+
+int main()
+{
+    // ArAtom has all the parameters for an argon atom
+    ArAtom arAtom;
+    // Create a particle with argon
+    ParticleType argonAtom(arAtom.name, arAtom.mass);
+    // Add the argon particle to a molecule
+    argonMolecule.addParticle(ParticleName("Ar"), argonAtom);
+    // Add non-bonded interactions for argon
+    interactions.add(argonAtom.name(), arAtom.c6, arAtom.c12);
+    // Add the requested number of argon molecules to a topology
+    topologyBuilder.addMolecule(argonMolecule, numParticles);
+    // Add the argon interactions to the topology
+    topologyBuilder.addParticleTypesInteractions(interactions);
+    // Build the topology
+    Topology topology = topologyBuilder.buildTopology();
+    // A simulation state contains all the molecular information about the system
+    SimulationState simState(coordinates, velocities, forces, box, topology);
+    // Use a simple cutoff rule for Coulomb
+    options.coulombType = BenchMarkCoulomb::Cutoff;
+    // Some performance flags can be set a run time
+    options.nbnxmSimd = BenchMarkKernels::Simd4XM;
+    // The force calculator contains all the data needed to compute forces
+    ForceCalculator forceCalculator(simState, options);
+    // Print some diagnostic info
+    printf("initial forces on particle 0: x %4f y %4f z %4f\n", forces[0][0], forces[0][1], forces[0][2]);
+    // The forces are handed back to the user
+    gmx::ArrayRef<gmx::RVec> userForces = forceCalculator.compute();
+    // Print some diagnostic info
+    printf("  final forces on particle 0: x %4f y %4f z %4f\n", userForces[0][0], userForces[0][1],
+           userForces[0][2]);
+    // The forces are not automatically updated in case the user wants to add their own
+    std::copy(userForces.begin(), userForces.end(), begin(simState.forces()));
+    // Integration requires masses, positions, and forces
+    LeapFrog integrator(simState);
+    // Print some diagnostic info
+    printf("initial position of particle 0: x %4f y %4f z %4f\n", simState.coordinates()[0][0],
+           simState.coordinates()[0][1], simState.coordinates()[0][2]);
+    // Integrate with a time step of 1 fs
+    integrator.integrate(1.0);
+    // Print some diagnostic info
+    printf("  final position of particle 0: x %4f y %4f z %4f\n", simState.coordinates()[0][0],
+           simState.coordinates()[0][1], simState.coordinates()[0][2]);
+    return 0;
+}


### PR DESCRIPTION
With this change, it is now possible to compile an external MD
program against nblib. A sample code computing forces and
performing integration with argon is added for demonstration
purposes. Since the sample code is linked to nblib, it is not
actually an external program, but it does compile as an
external program with the right linker and compiler flags.